### PR TITLE
fix(web): prevent Milkdown editor crash on page create and emoji update

### DIFF
--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -13,8 +13,6 @@ import type { EditorState } from 'prosemirror-state';
 import type { MarkType, NodeType } from 'prosemirror-model';
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
-import type { Page } from '@markdawn/shared';
-
 interface MilkdownEditorProps {
   pageId: string;
   workspaceId: string;
@@ -23,7 +21,6 @@ interface MilkdownEditorProps {
   onEditorReady?: (editor: unknown) => void;
   onProviderReady?: (provider: HocuspocusProvider) => void;
   onStatusChange?: (status: WebSocketStatus) => void;
-  pages?: Page[];
   onWikiLinkClick?: (path: string) => void;
 }
 
@@ -37,7 +34,6 @@ export function MilkdownEditor({
   onEditorReady,
   onStatusChange,
   onProviderReady,
-  pages,
   onWikiLinkClick,
 }: MilkdownEditorProps) {
   const doc = useMemo(() => new Y.Doc(), [pageId]);
@@ -105,47 +101,51 @@ export function MilkdownEditor({
   const updateActiveStates = useCallback(() => {
     const editorInstance = editorRef.current as unknown as { action: (cb: (ctx: unknown) => void) => void } | null;
     if (!editorInstance) return;
-    editorInstance.action((ctx) => {
-      const view = (ctx as unknown as { get: (key: unknown) => unknown }).get(editorViewCtx);
-      if (!view) return;
-      const { state } = view as { state: EditorState };
-      const schema = state.schema as unknown as { marks: Record<string, MarkType>; nodes: Record<string, NodeType> };
-      const marks = schema.marks;
-      const nodes = schema.nodes;
+    try {
+      editorInstance.action((ctx) => {
+        const view = (ctx as unknown as { get: (key: unknown) => unknown }).get(editorViewCtx);
+        if (!view) return;
+        const { state } = view as { state: EditorState };
+        const schema = state.schema as unknown as { marks: Record<string, MarkType>; nodes: Record<string, NodeType> };
+        const marks = schema.marks;
+        const nodes = schema.nodes;
 
-      const listItemNode = nodes.list_item;
-      const isInListItem = listItemNode ? hasParentBlockType(state, listItemNode) : false;
-      const listItemChecked = isInListItem && listItemNode
-        ? (() => {
-            const { $from } = state.selection;
-            for (let d = $from.depth; d > 0; d--) {
-              const node = $from.node(d);
-              if (node.type === listItemNode) {
-                const checked = node.attrs.checked;
-                return checked === true || checked === 'true';
+        const listItemNode = nodes.list_item;
+        const isInListItem = listItemNode ? hasParentBlockType(state, listItemNode) : false;
+        const listItemChecked = isInListItem && listItemNode
+          ? (() => {
+              const { $from } = state.selection;
+              for (let d = $from.depth; d > 0; d--) {
+                const node = $from.node(d);
+                if (node.type === listItemNode) {
+                  const checked = node.attrs.checked;
+                  return checked === true || checked === 'true';
+                }
               }
-            }
-            return false;
-          })()
-        : false;
+              return false;
+            })()
+          : false;
 
-      setActiveStates({
-        isBoldActive: hasMark(state, marks.strong),
-        isItalicActive: hasMark(state, marks.emphasis),
-        isStrikeActive: hasMark(state, marks.strike_through),
-        isCodeActive: hasMark(state, marks.inlineCode) || hasBlockType(state, nodes.code_block),
-        isLinkActive: hasMark(state, marks.link),
-        isH1Active: hasBlockType(state, nodes.heading, { level: 1 }),
-        isH2Active: hasBlockType(state, nodes.heading, { level: 2 }),
-        isH3Active: hasBlockType(state, nodes.heading, { level: 3 }),
-        isH4Active: hasBlockType(state, nodes.heading, { level: 4 }),
-        isH5Active: hasBlockType(state, nodes.heading, { level: 5 }),
-        isH6Active: hasBlockType(state, nodes.heading, { level: 6 }),
-        isBulletListActive: hasParentBlockType(state, nodes.bullet_list) && !listItemChecked,
-        isOrderedListActive: hasParentBlockType(state, nodes.ordered_list),
-        isTaskListActive: listItemChecked,
+        setActiveStates({
+          isBoldActive: hasMark(state, marks.strong),
+          isItalicActive: hasMark(state, marks.emphasis),
+          isStrikeActive: hasMark(state, marks.strike_through),
+          isCodeActive: hasMark(state, marks.inlineCode) || hasBlockType(state, nodes.code_block),
+          isLinkActive: hasMark(state, marks.link),
+          isH1Active: hasBlockType(state, nodes.heading, { level: 1 }),
+          isH2Active: hasBlockType(state, nodes.heading, { level: 2 }),
+          isH3Active: hasBlockType(state, nodes.heading, { level: 3 }),
+          isH4Active: hasBlockType(state, nodes.heading, { level: 4 }),
+          isH5Active: hasBlockType(state, nodes.heading, { level: 5 }),
+          isH6Active: hasBlockType(state, nodes.heading, { level: 6 }),
+          isBulletListActive: hasParentBlockType(state, nodes.bullet_list) && !listItemChecked,
+          isOrderedListActive: hasParentBlockType(state, nodes.ordered_list),
+          isTaskListActive: listItemChecked,
+        });
       });
-    });
+    } catch {
+      // Editor may have been destroyed
+    }
   }, [hasMark, hasBlockType, hasParentBlockType]);
 
   const provider = useMemo(() => {
@@ -168,7 +168,6 @@ export function MilkdownEditor({
     ...(onChange !== undefined && { onChange }),
     doc,
     provider,
-    pages,
     onWikiLinkClick,
   });
 
@@ -536,6 +535,8 @@ useEffect(() => {
       };
       
       onEditorReady?.(editorWrapper);
+    } else {
+      editorRef.current = null;
     }
   }, [editor, onEditorReady]);
 
@@ -592,12 +593,16 @@ useEffect(() => {
 
     return () => {
       isMounted = false;
-      editorInstanceRef.action((ctx) => {
-        const view = ctx.get(editorViewCtx);
-        if (!view) return;
-        view.dom.removeEventListener('keyup', handleSelectionChange);
-        view.dom.removeEventListener('mouseup', handleSelectionChange);
-      });
+      try {
+        editorInstanceRef.action((ctx) => {
+          const view = ctx.get(editorViewCtx);
+          if (!view) return;
+          view.dom.removeEventListener('keyup', handleSelectionChange);
+          view.dom.removeEventListener('mouseup', handleSelectionChange);
+        });
+      } catch {
+        // Editor may have been destroyed during cleanup race condition
+      }
     };
   }, [editor, updateActiveStates]);
 

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -25,7 +25,6 @@ import { linkEditor } from '../editor/components/LinkEditor';
 import 'katex/dist/katex.min.css';
 import type * as Y from 'yjs';
 import type { HocuspocusProvider } from '@hocuspocus/provider';
-import type { Page } from '@markdawn/shared';
 import { getLogger } from '../logger-init';
 
 interface UseMilkdownProps {
@@ -33,7 +32,6 @@ interface UseMilkdownProps {
   onChange?: (markdown: string) => void;
   doc?: Y.Doc;
   provider?: HocuspocusProvider;
-  pages?: Page[] | undefined;
   onWikiLinkClick?: ((path: string) => void) | undefined;
 }
 
@@ -80,10 +78,12 @@ function scrollToHeading(headingText: string): void {
   }
 }
 
-export function useMilkdown({ initialValue, onChange, doc, provider, pages, onWikiLinkClick }: UseMilkdownProps) {
+export function useMilkdown({ initialValue, onChange, doc, provider, onWikiLinkClick }: UseMilkdownProps) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const editorRef = useRef<Editor | null>(null);
   const [editorInstance, setEditorInstance] = useState<Editor | null>(null);
+  const onWikiLinkClickRef = useRef(onWikiLinkClick);
+  onWikiLinkClickRef.current = onWikiLinkClick;
   const hasCollab = Boolean(doc && provider);
   const fallbackInitialValue = hasCollab ? undefined : initialValue;
 
@@ -240,8 +240,8 @@ export function useMilkdown({ initialValue, onChange, doc, provider, pages, onWi
 
                   linkEditor.close();
 
-                  if (path && onWikiLinkClick) {
-                    onWikiLinkClick(path);
+                  if (path && onWikiLinkClickRef.current) {
+                    onWikiLinkClickRef.current(path);
                   } else if (heading) {
                     scrollToHeading(heading);
                   }
@@ -473,7 +473,7 @@ export function useMilkdown({ initialValue, onChange, doc, provider, pages, onWi
         floatingCopyBtn = null;
       }
     };
-  }, [container, fallbackInitialValue, hasCollab, onChange, doc, provider, pages, onWikiLinkClick]);
+  }, [container, fallbackInitialValue, hasCollab, onChange, doc, provider]);
 
   return { setContainer, editor: editorInstance };
 }

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -183,7 +183,6 @@ export default function Page() {
         initialValue={decodePageContent(page?.ydoc)}
         onProviderReady={setProvider}
         onStatusChange={handleStatusChange}
-        pages={flatPages}
         onWikiLinkClick={handleWikiLinkClick}
       />
       <BacklinksPanel pageId={pageId} workspaceSlug={workspaceSlug} />


### PR DESCRIPTION
## Summary

Fixes the `MilkdownError: Context \"editorView\" not found` crash that occurs when:
- Creating a new page (#5)
- Updating a page emoji (#3)

## Root Cause

The `pages` prop was included in the `useMilkdown` effect dependency array even though it was never used inside the editor initialization logic. Whenever the page tree refetched (after page creation, emoji update, or any other mutation), the `pages` array changed identity, causing the entire Milkdown editor to be destroyed and recreated. During this rapid cycle, React effect cleanups would call `.action()` on the already-destroyed editor instance, throwing the `editorView` context error.

## Changes

- **Removed unused `pages` prop** from `useMilkdown` and `MilkdownEditor` to stop unnecessary editor teardown/recreation
- **Added `try/catch` guards** around `editor.action()` calls in cleanup and active-states effects to safely handle the race condition where the editor is destroyed before cleanup runs
- **Used a ref for `onWikiLinkClick`** in `useMilkdown` so the callback stays fresh without being added to the effect dependency array
- **Reset `editorRef.current` to `null`** when the editor instance is unmounted to prevent stale references

## Verification

- `pnpm --filter @markdawn/web typecheck` passes
- `pnpm --filter @markdawn/web build` passes

## Fixes

- Fixes #5
- Fixes #3