### PR TITLE
feat(trash): add empty all button to trash

### DIFF
--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -164,6 +164,56 @@ pagesRoute.get("/trash", async (c) => {
   return c.json((result.rows as RawPageRow[]).map(normalizePageRow));
 });
 
+pagesRoute.delete("/trash/empty-all", async (c) => {
+  const workspaceId = c.req.query("workspaceId");
+  if (!workspaceId) {
+    throw new HTTPException(400, { message: "workspaceId is required" });
+  }
+
+  const user = c.get("user") as { id: string };
+  await ensureWorkspaceMember(workspaceId, user.id);
+
+  const workspacePages = await pool.query(
+    "select id, parent_id, is_deleted from pages where workspace_id = $1",
+    [workspaceId]
+  );
+
+  const childMap = new Map<string, string[]>();
+  const trashedPageIds = new Set<string>();
+
+  (workspacePages.rows as { id: string; parent_id: string | null; is_deleted: boolean }[]).forEach((item) => {
+    if (item.is_deleted) {
+      trashedPageIds.add(item.id);
+    }
+    if (!item.parent_id) {
+      return;
+    }
+    const list = childMap.get(item.parent_id) ?? [];
+    list.push(item.id);
+    childMap.set(item.parent_id, list);
+  });
+
+  const toDelete = new Set<string>();
+  const stack = Array.from(trashedPageIds);
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || toDelete.has(current)) {
+      continue;
+    }
+    toDelete.add(current);
+    const children = childMap.get(current);
+    if (children) {
+      children.forEach((child) => stack.push(child));
+    }
+  }
+
+  if (toDelete.size > 0) {
+    await pool.query("delete from pages where id = any($1)", [Array.from(toDelete)]);
+  }
+
+  return c.json({ deleted: true, count: toDelete.size });
+});
+
 pagesRoute.get("/recent", async (c) => {
   const workspaceId = c.req.query("workspaceId");
   if (!workspaceId) {

--- a/packages/web/src/components/sidebar/TrashView.tsx
+++ b/packages/web/src/components/sidebar/TrashView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Trash2, RotateCcw, FileText, X } from 'lucide-react';
-import { useTrashPages, useRestorePage, usePermanentDeletePage } from '../../hooks/use-pages';
+import { useTrashPages, useRestorePage, usePermanentDeletePage, useEmptyTrash } from '../../hooks/use-pages';
 import { showSuccessToast, showErrorToast } from '../../utils/toast';
 import { ConfirmDialog } from '../ConfirmDialog';
 import { EmptyState } from '../EmptyState';
@@ -14,8 +14,10 @@ export function TrashView({ workspaceId, onClose }: TrashViewProps) {
   const { data: trashPages, isLoading } = useTrashPages(workspaceId);
   const restoreMutation = useRestorePage();
   const permanentDeleteMutation = usePermanentDeletePage();
+  const emptyTrashMutation = useEmptyTrash();
 
   const [pageToDelete, setPageToDelete] = useState<{ id: string; title: string } | null>(null);
+  const [showEmptyAllConfirm, setShowEmptyAllConfirm] = useState(false);
 
   const handleRestore = async (pageId: string) => {
     try {
@@ -37,6 +39,15 @@ export function TrashView({ workspaceId, onClose }: TrashViewProps) {
     }
   };
 
+  const handleEmptyAll = async () => {
+    try {
+      await emptyTrashMutation.mutateAsync(workspaceId);
+      setShowEmptyAllConfirm(false);
+    } catch (error) {
+      showErrorToast("Failed to empty trash");
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/40 backdrop-blur-sm px-4 animate-fade-in">
       <div className="w-full max-w-2xl max-h-[80vh] flex flex-col rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 shadow-xl animate-slide-up">
@@ -45,12 +56,24 @@ export function TrashView({ workspaceId, onClose }: TrashViewProps) {
             <Trash2 size={18} />
             <h2 className="text-lg font-semibold">Trash</h2>
           </div>
-          <button
-            onClick={onClose}
-            className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
-          >
-            <X size={20} />
-          </button>
+          <div className="flex items-center gap-2">
+            {trashPages && trashPages.length > 0 && (
+              <button
+                onClick={() => setShowEmptyAllConfirm(true)}
+                disabled={emptyTrashMutation.isPending}
+                className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-red-600 dark:text-red-400 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded hover:bg-red-50 dark:hover:bg-red-900/20 hover:border-red-200 dark:hover:border-red-800 transition-colors disabled:opacity-50 cursor-pointer"
+              >
+                <Trash2 size={14} />
+                <span>Empty all</span>
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="p-1 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors cursor-pointer"
+            >
+              <X size={20} />
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto p-4">
@@ -123,6 +146,16 @@ export function TrashView({ workspaceId, onClose }: TrashViewProps) {
         onConfirm={handlePermanentDelete}
         onCancel={() => setPageToDelete(null)}
         loading={permanentDeleteMutation.isPending}
+      />
+
+      <ConfirmDialog
+        isOpen={showEmptyAllConfirm}
+        title="Empty trash"
+        message="Are you sure you want to permanently delete all items in the trash? This action cannot be undone."
+        confirmText="Empty trash"
+        onConfirm={handleEmptyAll}
+        onCancel={() => setShowEmptyAllConfirm(false)}
+        loading={emptyTrashMutation.isPending}
       />
     </div>
   );

--- a/packages/web/src/hooks/use-pages.ts
+++ b/packages/web/src/hooks/use-pages.ts
@@ -76,6 +76,15 @@ async function permanentDeletePage(pageId: string): Promise<void> {
   }
 }
 
+async function emptyTrash(workspaceId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/pages/trash/empty-all?workspaceId=${workspaceId}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to empty trash');
+  }
+}
+
 async function movePage(pageId: string, parentId: string | null, position: string): Promise<Page> {
   const res = await fetch(`${API_BASE}/pages/${pageId}/move`, {
     method: 'PATCH',
@@ -192,6 +201,20 @@ export function usePermanentDeletePage() {
     },
     onError: () => {
       showErrorToast('Failed to permanently delete page');
+    },
+  });
+}
+
+export function useEmptyTrash() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (workspaceId: string) => emptyTrash(workspaceId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['trashPages'] });
+      showSuccessToast('Trash emptied');
+    },
+    onError: () => {
+      showErrorToast('Failed to empty trash');
     },
   });
 }


### PR DESCRIPTION
## Summary

Adds an **Empty all** button to the Trash modal that permanently deletes all trashed pages (and their descendants) in a single action.

## Changes

- **API** (`packages/api/src/routes/pages.ts`): New `DELETE /trash/empty-all?workspaceId={id}` endpoint. Uses the same recursive child-deletion logic as the existing individual permanent-delete route.
- **Web hooks** (`packages/web/src/hooks/use-pages.ts`): Added `emptyTrash()` fetcher and `useEmptyTrash()` React Query mutation with toast notifications and cache invalidation.
- **UI** (`packages/web/src/components/sidebar/TrashView.tsx`): Added an **Empty all** button in the trash modal header (shown only when trash is not empty) with a confirmation dialog.

## Closes

- #7