### PR TITLE
feat(web): redesign toast notifications

### DIFF
--- a/packages/web/src/hooks/useTheme.ts
+++ b/packages/web/src/hooks/useTheme.ts
@@ -39,10 +39,12 @@ export function useTheme() {
 
       if (dark) {
         root.classList.add('dark');
+        root.setAttribute('data-mantine-color-scheme', 'dark');
       } else {
         root.classList.remove('dark');
+        root.setAttribute('data-mantine-color-scheme', 'light');
       }
-      
+
       localStorage.setItem('markdawn-theme', theme);
     };
 

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -4,16 +4,28 @@
 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --color-surface: theme(colors.zinc.50);
-  --color-surface-alt: theme(colors.zinc.100);
-  --color-surface-elevated: theme(colors.zinc.200);
-  --color-border: theme(colors.zinc.300);
-  --color-text: theme(colors.zinc.900);
-  --color-text-muted: theme(colors.zinc.600);
   --z-index-dropdown: 40;
   --z-index-modal: 50;
   --z-index-overlay: 60;
   --z-index-toast: 70;
+}
+
+:root {
+  --color-surface: #fafafa;
+  --color-surface-alt: #f4f4f5;
+  --color-surface-elevated: #e4e4e7;
+  --color-border: #d4d4d8;
+  --color-text: #18181b;
+  --color-text-muted: #52525b;
+}
+
+.dark {
+  --color-surface: #09090b;
+  --color-surface-alt: #18181b;
+  --color-surface-elevated: #27272a;
+  --color-border: #3f3f46;
+  --color-text: #fafafa;
+  --color-text-muted: #a1a1aa;
 }
 
 @layer base {
@@ -48,6 +60,17 @@
   }
 }
 
+@keyframes slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 @keyframes slide-right {
   from {
     transform: translateX(-100%);
@@ -75,6 +98,7 @@
 
 .animate-fade-in { animation: fade-in 150ms ease-out; }
 .animate-slide-up { animation: slide-up 200ms ease-out; }
+.animate-slide-down { animation: slide-down 200ms ease-out; }
 .animate-slide-right { animation: slide-right 200ms ease-out; }
 .animate-shimmer { animation: shimmer 1.5s linear infinite; }
 .animate-scale-in { animation: scale-in 150ms ease-out; }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -37,6 +37,11 @@ const theme = createTheme({
           backgroundColor: 'var(--color-surface-elevated)',
           border: `1px solid var(--color-border)`,
           color: 'var(--color-text)',
+          width: 'fit-content',
+          minWidth: '240px',
+          maxWidth: '420px',
+          marginLeft: 'auto',
+          marginRight: 'auto',
         },
         title: {
           color: 'var(--color-text)',
@@ -54,7 +59,7 @@ const queryClient = new QueryClient()
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <MantineProvider theme={theme}>
-      <Notifications transitionDuration={300} />
+      <Notifications position="top-center" transitionDuration={300} />
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>

--- a/packages/web/src/utils/toast.tsx
+++ b/packages/web/src/utils/toast.tsx
@@ -8,7 +8,8 @@ export function showSuccessToast(message: string) {
     icon: <IconCheck size={16} />,
     autoClose: 4000,
     withBorder: true,
-    className: 'animate-slide-up',
+    withCloseButton: true,
+    className: 'animate-slide-down',
   })
 }
 
@@ -19,7 +20,8 @@ export function showErrorToast(message: string) {
     icon: <IconX size={16} />,
     autoClose: 5000,
     withBorder: true,
-    className: 'animate-slide-up',
+    withCloseButton: true,
+    className: 'animate-slide-down',
   })
 }
 
@@ -30,6 +32,7 @@ export function showInfoToast(message: string) {
     icon: <IconInfoCircle size={16} />,
     autoClose: 4000,
     withBorder: true,
-    className: 'animate-slide-up',
+    withCloseButton: true,
+    className: 'animate-slide-down',
   })
 }


### PR DESCRIPTION
Closes #9

## Summary
Redesigned toast notifications to match the requested style:

- **Position**: Moved from bottom-right to top-center
- **Dark mode**: Added full dark mode support via CSS custom properties and `data-mantine-color-scheme` attribute
- **Animation**: Added slide-down enter animation for top placement
- **Close button**: Added close button to all toast variants (success, error, info)
- **Width**: Toasts now fit their content width (min 240px, max 420px) and are properly centered