### PR TITLE
feat(dev): add podman scripts for local PostgreSQL management

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "build": "pnpm -r --workspace-concurrency=1 run build",
     "lint": "pnpm -r run lint",
     "test": "pnpm -r run test",
-    "typecheck": "pnpm -r run typecheck"
+    "typecheck": "pnpm -r run typecheck",
+    "db:start": "bash scripts/db-start.sh",
+    "db:stop": "bash scripts/db-stop.sh",
+    "db:reset": "bash scripts/db-reset.sh",
+    "dev:full": "pnpm db:start && pnpm dev"
   },
   "pnpm": {
     "overrides": {

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="markdawn-postgres-dev"
+VOLUME_NAME="markdawn-postgres-dev-data"
+
+echo "Resetting dev database..."
+podman rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+podman volume rm "$VOLUME_NAME" >/dev/null 2>&1 || true
+echo "Database reset. Run 'pnpm db:start' to create a fresh instance."

--- a/scripts/db-start.sh
+++ b/scripts/db-start.sh
@@ -5,7 +5,7 @@ CONTAINER_NAME="markdawn-postgres-dev"
 VOLUME_NAME="markdawn-postgres-dev-data"
 ENV_FILE=".env"
 
-# Load credentials from .env.dev if present
+# Load credentials from .env if present (typically copied from .env.dev)
 DB_USER="markdawn"
 DB_PASSWORD="password"
 DB_NAME="markdawn"

--- a/scripts/db-start.sh
+++ b/scripts/db-start.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="markdawn-postgres-dev"
+VOLUME_NAME="markdawn-postgres-dev-data"
+ENV_FILE=".env"
+
+# Load credentials from .env.dev if present
+DB_USER="markdawn"
+DB_PASSWORD="password"
+DB_NAME="markdawn"
+
+if [ -f "$ENV_FILE" ]; then
+  while IFS='=' read -r key value; do
+    case "$key" in
+      POSTGRES_USER) DB_USER="$value" ;;
+      POSTGRES_PASSWORD) DB_PASSWORD="$value" ;;
+      POSTGRES_DB) DB_NAME="$value" ;;
+    esac
+  done < <(grep -v '^#' "$ENV_FILE" | grep -E '^(POSTGRES_USER|POSTGRES_PASSWORD|POSTGRES_DB)=')
+fi
+
+echo "Starting PostgreSQL dev container..."
+
+# Ensure volume exists
+podman volume create "$VOLUME_NAME" >/dev/null 2>&1 || true
+
+# Run container with --replace for idempotency
+podman run -d \
+  --name "$CONTAINER_NAME" \
+  --replace \
+  -e POSTGRES_USER="$DB_USER" \
+  -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+  -e POSTGRES_DB="$DB_NAME" \
+  -v "$VOLUME_NAME:/var/lib/postgresql/data:Z" \
+  -p 5432:5432 \
+  --health-cmd="pg_isready -U \"$DB_USER\" -d \"$DB_NAME\"" \
+  --health-interval=5s \
+  --health-timeout=3s \
+  --health-retries=5 \
+  docker.io/library/postgres:17-alpine \
+  >/dev/null
+
+echo "Waiting for PostgreSQL to be ready..."
+for i in {1..30}; do
+  if podman healthcheck run "$CONTAINER_NAME" >/dev/null 2>&1; then
+    echo "PostgreSQL is ready on localhost:5432 (database: $DB_NAME)"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ERROR: PostgreSQL failed to become healthy within 30 seconds."
+exit 1

--- a/scripts/db-stop.sh
+++ b/scripts/db-stop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="markdawn-postgres-dev"
+
+echo "Stopping PostgreSQL dev container..."
+podman stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+podman rm "$CONTAINER_NAME" >/dev/null 2>&1 || true
+echo "Stopped."


### PR DESCRIPTION
## Summary

Adds shell scripts to manage a local PostgreSQL container for development using Podman. This removes the need to manually start Postgres before `pnpm dev`.

## Changes

- `scripts/db-start.sh` — idempotent start with healthcheck wait
- `scripts/db-stop.sh` — clean stop and remove
- `scripts/db-reset.sh` — wipe volume for a clean slate
- New `package.json` scripts: `db:start`, `db:stop`, `db:reset`, `dev:full`

## Daily Workflow

```bash
# First time / after reboot
pnpm db:start

# Normal dev work
pnpm dev

# Or both in one shot
pnpm dev:full

# Clean slate when needed
pnpm db:reset && pnpm db:start
```

## Why podman-run over podman-compose

- `podman-compose` is effectively unmaintained (last commit ~5 months ago)
- Shell scripts align with our existing Podman-first infrastructure (Quadlet in production)
- Zero additional dependencies for a single container
- Named volume `markdawn-postgres-dev-data` persists data across restarts
- Reads credentials from `.env.dev` with sensible defaults