### PR TITLE
fix(ci): shared package missing from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared package
+        run: pnpm --filter @markdawn/shared build
+
       - name: Typecheck
         run: pnpm typecheck
 
@@ -70,6 +73,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @markdawn/shared build
 
       - name: Install Podman
         run: |


### PR DESCRIPTION
Fixed it by moving build step to the top. New order is build -> lint -> typecheck -> test