### PR TITLE
feat(web): collaborative cursors with user avatars

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,4 +3,5 @@ export * from './types/workspace.js';
 export * from './types/page.js';
 export * from './types/api.js';
 export * from './utils/position.js';
+export * from './utils/color.js';
 export * from './logger.js';

--- a/packages/shared/src/utils/color.ts
+++ b/packages/shared/src/utils/color.ts
@@ -33,3 +33,15 @@ export function getStableColor(id: string): string {
   const index = Math.abs(hash) % COLORS.length;
   return COLORS[index] ?? '#3F51B5';
 }
+
+/**
+ * Returns black or white text color based on background luminance.
+ * Uses the W3C relative luminance formula (sRGB).
+ */
+export function getContrastColor(hex: string): '#000000' | '#ffffff' {
+  const r = Number.parseInt(hex.slice(1, 3), 16) / 255;
+  const g = Number.parseInt(hex.slice(3, 5), 16) / 255;
+  const b = Number.parseInt(hex.slice(5, 7), 16) / 255;
+  const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+}

--- a/packages/shared/src/utils/color.ts
+++ b/packages/shared/src/utils/color.ts
@@ -1,0 +1,35 @@
+const COLORS = [
+  '#E0282E', // Red
+  '#E91E63', // Pink
+  '#9C27B0', // Purple
+  '#673AB7', // Deep Purple
+  '#3F51B5', // Indigo
+  '#2196F3', // Blue
+  '#03A9F4', // Light Blue
+  '#00BCD4', // Cyan
+  '#009688', // Teal
+  '#4CAF50', // Green
+  '#8BC34A', // Light Green
+  '#CDDC39', // Lime
+  '#FFC107', // Amber
+  '#FF9800', // Orange
+  '#FF5722', // Deep Orange
+  '#795548', // Brown
+  '#607D8B', // Blue Grey
+  '#333333', // Dark Grey
+  '#D4D4D8', // Zinc
+  '#06B6D4', // Sky
+];
+
+/**
+ * Deterministically maps a string ID to one of 20 professional colors.
+ */
+export function getStableColor(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = id.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const index = Math.abs(hash) % COLORS.length;
+  return COLORS[index] ?? '#3F51B5';
+}

--- a/packages/web/src/components/editor/CollabStatus.test.tsx
+++ b/packages/web/src/components/editor/CollabStatus.test.tsx
@@ -6,8 +6,8 @@ import { CollabStatus } from './CollabStatus';
 const mockAwareness = {
   getStates: vi.fn().mockReturnValue(
     new Map([
-      ['u1', {}],
-      ['u2', {}],
+      ['u1', { user: { name: 'User 1', color: '#ff0000' } }],
+      ['u2', { user: { name: 'User 2', color: '#00ff00' } }],
     ]),
   ),
   on: vi.fn(),
@@ -29,28 +29,31 @@ describe('CollabStatus', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows connecting status with amber dot', () => {
+  it('shows connecting status label and amber dot', () => {
     const provider = createMockProvider(WebSocketStatus.Connecting);
     render(<CollabStatus provider={provider} status={WebSocketStatus.Connecting} />);
 
+    expect(screen.getByText('User 1')).toBeInTheDocument();
     expect(screen.getByText('Connecting')).toBeInTheDocument();
     const dot = document.querySelector('.bg-amber-500');
     expect(dot).toBeInTheDocument();
   });
 
-  it('shows connected status with emerald dot', () => {
+  it('shows connected status label and emerald dot', () => {
     const provider = createMockProvider(WebSocketStatus.Connected);
     render(<CollabStatus provider={provider} status={WebSocketStatus.Connected} />);
 
+    expect(screen.getByText('User 1')).toBeInTheDocument();
     expect(screen.getByText('Live')).toBeInTheDocument();
     const dot = document.querySelector('.bg-emerald-500');
     expect(dot).toBeInTheDocument();
   });
 
-  it('shows disconnected status with rose dot', () => {
+  it('shows disconnected status label and rose dot', () => {
     const provider = createMockProvider(WebSocketStatus.Disconnected);
     render(<CollabStatus provider={provider} status={WebSocketStatus.Disconnected} />);
 
+    expect(screen.getByText('User 1')).toBeInTheDocument();
     expect(screen.getByText('Offline')).toBeInTheDocument();
     const dot = document.querySelector('.bg-rose-500');
     expect(dot).toBeInTheDocument();

--- a/packages/web/src/components/editor/CollabStatus.tsx
+++ b/packages/web/src/components/editor/CollabStatus.tsx
@@ -1,29 +1,28 @@
-import type { HocuspocusProvider } from '@hocuspocus/provider';
-import type { WebSocketStatus } from '@hocuspocus/provider';
+import type { HocuspocusProvider, WebSocketStatus } from '@hocuspocus/provider';
 import React, { useEffect, useState } from 'react';
+import { getInitial } from '../../utils/avatar';
 import { Tooltip } from '../Tooltip';
 
 type CollabStatusProps = {
   provider: HocuspocusProvider | null;
-  status: ProviderStatus;
+  status: WebSocketStatus;
 };
 
-type ProviderStatus = WebSocketStatus;
+type AwarenessUser = {
+  id: number;
+  name: string;
+  color: string;
+  avatar?: string;
+};
 
-const STATUS_LABELS: Record<ProviderStatus, string> = {
+const STATUS_LABELS: Record<WebSocketStatus, string> = {
   connecting: 'Connecting',
   connected: 'Live',
   disconnected: 'Offline',
 };
 
-const STATUS_COLORS: Record<ProviderStatus, string> = {
-  connecting: 'bg-amber-500',
-  connected: 'bg-emerald-500',
-  disconnected: 'bg-rose-500',
-};
-
 export function CollabStatus({ provider, status }: CollabStatusProps) {
-  const [userCount, setUserCount] = useState(1);
+  const [users, setUsers] = useState<AwarenessUser[]>([]);
 
   useEffect(() => {
     if (!provider) {
@@ -32,8 +31,24 @@ export function CollabStatus({ provider, status }: CollabStatusProps) {
 
     const updateUsers = () => {
       const awareness = provider.awareness;
-      const count = awareness ? awareness.getStates().size : 1;
-      setUserCount(count || 1);
+      if (!awareness) return;
+
+      const states = awareness.getStates();
+      const activeUsers: AwarenessUser[] = [];
+
+      for (const [clientId, state] of states.entries()) {
+        if (state.user && typeof state.user === 'object') {
+          const user = state.user as { name?: string; color?: string; avatar?: string };
+          activeUsers.push({
+            id: clientId,
+            name: user.name ?? 'Anonymous',
+            color: user.color ?? '#000000',
+            ...(user.avatar ? { avatar: user.avatar } : {}),
+          });
+        }
+      }
+
+      setUsers(activeUsers);
     };
 
     provider.awareness?.on('change', updateUsers);
@@ -45,23 +60,62 @@ export function CollabStatus({ provider, status }: CollabStatusProps) {
   }, [provider]);
 
   const label = STATUS_LABELS[status] ?? 'Connecting';
-  const dotClass = STATUS_COLORS[status] ?? STATUS_COLORS.connecting;
+  const statusColor =
+    status === 'connected'
+      ? 'bg-emerald-500'
+      : status === 'connecting'
+        ? 'bg-amber-500'
+        : 'bg-rose-500';
 
   if (!provider) {
     return null;
   }
 
   return (
-    <Tooltip label={label} position="bottom">
-      <span
-        className={
-          'relative flex w-9 h-9 items-center justify-center rounded-md transition-colors duration-200 group-hover:bg-zinc-100 dark:group-hover:bg-zinc-800 cursor-pointer'
-        }
-      >
-        <span
-          className={`inline-flex h-3 w-3 rounded-full transition-colors duration-300 ${dotClass}`}
-        />
-      </span>
-    </Tooltip>
+    <div className="flex items-center gap-3">
+      {/* Status Indicator */}
+      <Tooltip label={label} position="bottom">
+        <span className="relative flex w-9 h-9 items-center justify-center rounded-md transition-colors duration-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer">
+          <span
+            className={`inline-flex h-3 w-3 rounded-full transition-colors duration-300 ${statusColor}`}
+          />
+        </span>
+      </Tooltip>
+
+      {/* User Avatars */}
+      {users.length > 1 && (
+        <div className="flex items-center -space-x-2">
+          {users.slice(0, 5).map((user) => (
+            <Tooltip key={user.id} label={user.name} position="bottom">
+              <div
+                className="relative w-8 h-8 rounded-full border-[2.5px] bg-zinc-100 dark:bg-zinc-800 overflow-hidden flex items-center justify-center transition-transform hover:scale-110 hover:z-10"
+                style={{
+                  borderColor: user.color,
+                  backgroundColor: user.avatar ? undefined : user.color,
+                }}
+              >
+                {user.avatar ? (
+                  <img
+                    src={user.avatar}
+                    alt={user.name}
+                    className="w-full h-full object-cover"
+                    referrerPolicy="no-referrer"
+                  />
+                ) : (
+                  <span className="text-white text-xs font-bold">{getInitial(user.name)}</span>
+                )}
+              </div>
+            </Tooltip>
+          ))}
+          {users.length > 5 && (
+            <Tooltip label={`${users.length - 5} more users`} position="bottom">
+              <div className="w-8 h-8 rounded-full border-2 border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 flex items-center justify-center text-[10px] font-bold text-zinc-500 dark:text-zinc-400">
+                +{users.length - 5}
+              </div>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/web/src/components/editor/CollabStatus.tsx
+++ b/packages/web/src/components/editor/CollabStatus.tsx
@@ -34,9 +34,11 @@ export function CollabStatus({ provider, status }: CollabStatusProps) {
       if (!awareness) return;
 
       const states = awareness.getStates();
+      const localClientId = awareness.clientID;
       const activeUsers: AwarenessUser[] = [];
 
       for (const [clientId, state] of states.entries()) {
+        if (clientId === localClientId) continue;
         if (state.user && typeof state.user === 'object') {
           const user = state.user as { name?: string; color?: string; avatar?: string };
           activeUsers.push({
@@ -83,7 +85,7 @@ export function CollabStatus({ provider, status }: CollabStatusProps) {
       </Tooltip>
 
       {/* User Avatars */}
-      {users.length > 1 && (
+      {users.length > 0 && (
         <div className="flex items-center -space-x-2">
           {users.slice(0, 5).map((user) => (
             <Tooltip key={user.id} label={user.name} position="bottom">

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAwareness } from '../../hooks/useAwareness';
 import { useFloatingToolbar } from '../../hooks/useFloatingToolbar';
 import { useMilkdown } from '../../hooks/useMilkdown';
 import { useWikiLinkSuggestions } from '../../hooks/useWikiLinkSuggestions';
@@ -11,7 +12,6 @@ import { commandsCtx, editorViewCtx } from '@milkdown/core';
 import type { Editor } from '@milkdown/core';
 import type { EditorView } from '@milkdown/kit/prose/view';
 import { insertTableCommand } from '@milkdown/preset-gfm';
-import { replaceAll } from '@milkdown/utils';
 import { setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
 import type { MarkType, NodeType } from 'prosemirror-model';
 import type { EditorState } from 'prosemirror-state';
@@ -34,7 +34,6 @@ interface MilkdownEditorProps {
   workspaceId: string;
   initialValue?: string;
   onChange?: (markdown: string) => void;
-  onEditorReady?: (editor: unknown) => void;
   onProviderReady?: (provider: HocuspocusProvider) => void;
   onStatusChange?: (status: WebSocketStatus) => void;
   onWikiLinkClick?: (path: string) => void;
@@ -47,7 +46,6 @@ export function MilkdownEditor({
   workspaceId,
   initialValue,
   onChange,
-  onEditorReady,
   onStatusChange,
   onProviderReady,
   onWikiLinkClick,
@@ -207,6 +205,8 @@ export function MilkdownEditor({
     onWikiLinkClick,
     onWikiLinkSuggest: handleWikiLinkSuggest,
   });
+
+  useAwareness(provider);
 
   const { visible, position, keepVisible } = useFloatingToolbar();
 
@@ -619,42 +619,8 @@ export function MilkdownEditor({
   }, [provider, pageId]);
 
   useEffect(() => {
-    if (editor) {
-      editorRef.current = editor;
-      const editorWrapper = {
-        milkdown: editor,
-        document: [],
-        onChange: () => () => {},
-        replaceBlocks: (
-          _doc: unknown,
-          blocks: Array<{
-            type: string;
-            props?: Record<string, unknown>;
-            content?: Array<{ text?: string }>;
-          }>,
-        ) => {
-          const markdown = blocks
-            .map((b) => {
-              if (b.type === 'heading') {
-                const level = typeof b.props?.level === 'number' ? b.props.level : 1;
-                return `${'#'.repeat(level)} ${b.content?.[0]?.text || ''}`;
-              }
-              if (b.type === 'paragraph') {
-                return b.content?.[0]?.text || '';
-              }
-              return '';
-            })
-            .join('\n\n');
-
-          editor.action(replaceAll(markdown));
-        },
-      };
-
-      onEditorReady?.(editorWrapper);
-    } else {
-      editorRef.current = null;
-    }
-  }, [editor, onEditorReady]);
+    editorRef.current = editor;
+  }, [editor]);
 
   const isMountedRef = useRef(true);
   const latestProviderRef = useRef(provider);

--- a/packages/web/src/components/editor/editor.css
+++ b/packages/web/src/components/editor/editor.css
@@ -797,3 +797,95 @@
 .milkdown-editor-view td.selectedCell {
   outline-offset: -2px;
 }
+
+/* Collaborative Cursors */
+.ProseMirror-yjs-cursor {
+  position: absolute;
+  border-left: 2px solid;
+  height: 1.2em;
+  word-break: normal;
+  /* Remove pointer-events: none so hover works */
+  user-select: none;
+  z-index: 5;
+}
+
+/* Larger invisible hitarea to make hovering easier */
+.ProseMirror-yjs-cursor-hitarea {
+  position: absolute;
+  top: -4px;
+  left: -10px;
+  width: 20px;
+  height: calc(100% + 8px);
+  background: transparent;
+  pointer-events: auto;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.ProseMirror-yjs-cursor > .ProseMirror-yjs-cursor-pill {
+  position: absolute;
+  top: -26px;
+  left: -2px;
+  display: inline-flex;
+  width: max-content;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px 2px 2px;
+  border-radius: 4px;
+  color: white;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: all 0.15s ease-out;
+  pointer-events: none;
+  z-index: 20;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+/* Reveal pill when hovering either the line or the hitarea */
+.ProseMirror-yjs-cursor:hover > .ProseMirror-yjs-cursor-pill {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* The tiny flag/cap at the top */
+.ProseMirror-yjs-cursor::after {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 1px;
+  background-color: inherit;
+  z-index: 10;
+}
+
+.ProseMirror-yjs-cursor-pill img {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.ProseMirror-yjs-cursor-initials {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* Collaborative Selection */
+.yjs-selection {
+  opacity: 0.3;
+  pointer-events: none;
+}

--- a/packages/web/src/hooks/useAwareness.ts
+++ b/packages/web/src/hooks/useAwareness.ts
@@ -1,0 +1,23 @@
+import type { HocuspocusProvider } from '@hocuspocus/provider';
+import { getStableColor } from '@markdawn/shared';
+import { useEffect } from 'react';
+import { useAuth } from './useAuth';
+
+export function useAwareness(provider: HocuspocusProvider | null) {
+  const { data: session } = useAuth();
+
+  useEffect(() => {
+    if (!provider || !provider.awareness || !session?.user) return;
+
+    const userColor = getStableColor(session.user.id);
+    provider.awareness.setLocalStateField('user', {
+      name: session.user.name || 'Anonymous',
+      color: userColor,
+      avatar: session.user.image,
+    });
+
+    return () => {
+      provider.awareness?.setLocalStateField('user', null);
+    };
+  }, [provider, session]);
+}

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -34,6 +34,40 @@ import 'katex/dist/katex.min.css';
 import type { HocuspocusProvider } from '@hocuspocus/provider';
 import type * as Y from 'yjs';
 import { getLogger } from '../logger-init';
+import { getInitial } from '../utils/avatar';
+
+const cursorBuilder = (user: { name: string; color: string; avatar?: string }) => {
+  const cursor = document.createElement('span');
+  cursor.classList.add('ProseMirror-yjs-cursor');
+  cursor.style.borderColor = user.color;
+
+  const hitArea = document.createElement('div');
+  hitArea.classList.add('ProseMirror-yjs-cursor-hitarea');
+  cursor.appendChild(hitArea);
+
+  const pill = document.createElement('div');
+  pill.classList.add('ProseMirror-yjs-cursor-pill');
+  pill.style.backgroundColor = user.color;
+
+  if (user.avatar) {
+    const img = document.createElement('img');
+    img.src = user.avatar;
+    img.alt = user.name;
+    pill.appendChild(img);
+  } else {
+    const initials = document.createElement('div');
+    initials.classList.add('ProseMirror-yjs-cursor-initials');
+    initials.innerText = getInitial(user.name);
+    pill.appendChild(initials);
+  }
+
+  const name = document.createElement('span');
+  name.innerText = user.name;
+  pill.appendChild(name);
+
+  cursor.appendChild(pill);
+  return cursor;
+};
 
 function isLikelyMarkdown(value: string): boolean {
   const trimmed = value.trim();
@@ -288,6 +322,14 @@ export function useMilkdown({
               suggest(false, '', null);
             }
           });
+
+          if (withCollab) {
+            ctx.get(collabServiceCtx).setOptions({
+              yCursorOpts: {
+                cursorBuilder,
+              },
+            });
+          }
 
           ctx.update(editorViewOptionsCtx, (prev) => ({
             ...prev,

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -32,6 +32,7 @@ import { wikiLink } from '../editor/plugins/wikilink';
 import { repairDocument } from '../editor/utils/documentRepair';
 import 'katex/dist/katex.min.css';
 import type { HocuspocusProvider } from '@hocuspocus/provider';
+import { getContrastColor } from '@markdawn/shared';
 import type * as Y from 'yjs';
 import { getLogger } from '../logger-init';
 import { getInitial } from '../utils/avatar';
@@ -40,6 +41,7 @@ const cursorBuilder = (user: { name: string; color: string; avatar?: string }) =
   const cursor = document.createElement('span');
   cursor.classList.add('ProseMirror-yjs-cursor');
   cursor.style.borderColor = user.color;
+  cursor.style.backgroundColor = user.color;
 
   const hitArea = document.createElement('div');
   hitArea.classList.add('ProseMirror-yjs-cursor-hitarea');
@@ -48,11 +50,13 @@ const cursorBuilder = (user: { name: string; color: string; avatar?: string }) =
   const pill = document.createElement('div');
   pill.classList.add('ProseMirror-yjs-cursor-pill');
   pill.style.backgroundColor = user.color;
+  pill.style.color = getContrastColor(user.color);
 
   if (user.avatar) {
     const img = document.createElement('img');
     img.src = user.avatar;
     img.alt = user.name;
+    img.referrerPolicy = 'no-referrer';
     pill.appendChild(img);
   } else {
     const initials = document.createElement('div');

--- a/packages/web/src/utils/avatar.ts
+++ b/packages/web/src/utils/avatar.ts
@@ -1,0 +1,3 @@
+export function getInitial(name: string): string {
+  return name.slice(0, 1).toUpperCase();
+}


### PR DESCRIPTION
## Summary

Adds real-time collaborative cursor visualization and user presence avatars to the editor. When multiple users edit the same document, each user sees colored cursor indicators with name pills and avatar display for all other participants.

## Changes

- **`packages/shared/src/utils/color.ts`** — `getStableColor` utility that deterministically maps a user ID to one of 20 professional colors
- **`packages/web/src/utils/avatar.ts`** — `getInitial` extracts the first character of a display name as avatar fallback
- **`packages/web/src/hooks/useAwareness.ts`** — Hook that sets the local user's awareness state (name, color, avatar) and clears it on unmount
- **`packages/web/src/components/editor/CollabStatus.tsx`** — Status indicator component showing connection state (connecting/connected/disconnected) and up to 5 user avatars with tooltips; uses awareness client IDs as React keys
- **`packages/web/src/components/editor/CollabStatus.test.tsx`** — Tests for connection states, listener registration, and cleanup
- **`packages/web/src/hooks/useMilkdown.ts`** — `cursorBuilder` renders remote cursors with avatar images/initials and name pills, wired via y-prosemirror
- **`packages/web/src/components/editor/editor.css`** — Styles for cursor lines, hover-activated name pills, selection highlights
- **`packages/web/src/components/editor/MilkdownEditor.tsx`** — Wires `useAwareness` and removes unused `onEditorReady` prop

## Commits

5 atomic commits building up from utilities to integration.

## Verification

- TypeScript: `tsc --noEmit` passes across all packages
- Tests: 6/6 pass (CollabStatus)
- Avatar images use `referrerPolicy="no-referrer"` for privacy
- No orphaned cursor DOM — y-prosemirror handles cleanup on awareness change