### PR TITLE
fix(web): update code block copy button to icon, fix positioning, add theme support

### DIFF
--- a/packages/web/src/components/editor/editor.css
+++ b/packages/web/src/components/editor/editor.css
@@ -114,6 +114,7 @@
 }
 
 .milkdown-editor-view pre {
+  position: relative;
   background-color: #f3f4f6;
   padding: 1rem;
   border-radius: 0.5rem;
@@ -130,10 +131,14 @@
   top: 0.5rem;
   right: 0.5rem;
   opacity: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   background: rgba(17, 24, 39, 0.7);
   color: #f9fafb;
   border: 1px solid rgba(255, 255, 255, 0.2);
-  padding: 4px 8px;
   border-radius: 4px;
   cursor: pointer;
   transition: opacity 0.15s ease;
@@ -179,6 +184,21 @@
   background: rgba(255, 255, 255, 0.1);
   color: #e5e7eb;
   border-color: rgba(229, 231, 235, 0.25);
+}
+
+/* Floating code block copy button (attached to body, not inside .milkdown-editor-view) */
+.code-block-copy-btn {
+  background: rgba(255, 255, 255, 0.95);
+  color: #18181b;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.dark .code-block-copy-btn {
+  background: rgba(30, 30, 35, 0.85);
+  color: #e5e7eb;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 .dark .milkdown-editor-view li[data-item-type="task"]::before {

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -231,18 +231,55 @@ export function useMilkdown({
     let floatingCopyBtn: HTMLButtonElement | null = null;
     let currentPre: HTMLElement | null = null;
 
+    const copyIconSvg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>';
+    const checkIconSvg =
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
+
     const getCopyButton = (): HTMLButtonElement => {
       if (!floatingCopyBtn) {
         floatingCopyBtn = document.createElement('button');
         floatingCopyBtn.className = 'code-block-copy-btn';
-        floatingCopyBtn.textContent = 'Copy';
         floatingCopyBtn.type = 'button';
-        floatingCopyBtn.style.position = 'fixed';
-        floatingCopyBtn.style.zIndex = '1000';
-        floatingCopyBtn.style.opacity = '0';
-        floatingCopyBtn.style.pointerEvents = 'none';
-        floatingCopyBtn.style.transition = 'opacity 0.15s ease';
-        document.body.appendChild(floatingCopyBtn);
+        floatingCopyBtn.innerHTML = copyIconSvg;
+        floatingCopyBtn.setAttribute('aria-label', 'Copy code');
+        Object.assign(floatingCopyBtn.style, {
+          position: 'absolute',
+          zIndex: '1000',
+          opacity: '0',
+          pointerEvents: 'none',
+          transition: 'opacity 0.15s ease',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '28px',
+          height: '28px',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        });
+        const wrapper = container?.parentElement;
+        const mountTarget = wrapper ?? document.body;
+        if (wrapper && getComputedStyle(wrapper).position === 'static') {
+          wrapper.style.position = 'relative';
+        }
+        mountTarget.appendChild(floatingCopyBtn);
+
+        floatingCopyBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (!currentPre) return;
+          const code = currentPre.querySelector('code');
+          if (!code) return;
+          navigator.clipboard.writeText(code.textContent || '').catch((err) => {
+            getLogger().warn('Failed to copy code block:', err);
+          });
+          if (floatingCopyBtn) {
+            floatingCopyBtn.innerHTML = checkIconSvg;
+            setTimeout(() => {
+              if (floatingCopyBtn) floatingCopyBtn.innerHTML = copyIconSvg;
+            }, 1500);
+          }
+        });
       }
       return floatingCopyBtn;
     };
@@ -254,27 +291,14 @@ export function useMilkdown({
       const btn = getCopyButton();
       currentPre = pre;
 
-      const rect = pre.getBoundingClientRect();
-      btn.style.top = `${rect.top + 8}px`;
-      btn.style.left = `${rect.right - 72}px`;
+      const wrapperRect = container?.parentElement?.getBoundingClientRect();
+      const preRect = pre.getBoundingClientRect();
+      if (wrapperRect) {
+        btn.style.top = `${preRect.top - wrapperRect.top + 8}px`;
+        btn.style.right = `${wrapperRect.right - preRect.right + 8}px`;
+      }
       btn.style.opacity = '1';
       btn.style.pointerEvents = 'auto';
-
-      const newBtn = btn.cloneNode(true) as HTMLButtonElement;
-      btn.parentNode?.replaceChild(newBtn, btn);
-      floatingCopyBtn = newBtn;
-
-      floatingCopyBtn.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void navigator.clipboard.writeText(code.textContent || '');
-        if (floatingCopyBtn) {
-          floatingCopyBtn.textContent = 'Copied!';
-          setTimeout(() => {
-            if (floatingCopyBtn) floatingCopyBtn.textContent = 'Copy';
-          }, 1500);
-        }
-      });
     };
 
     const hideCopyButton = (): void => {


### PR DESCRIPTION
Closes #25

## Summary

Rewrote the code block copy button to address all three issues in #25:

### Changes

- **Text → Icon**: Replaced plain text "Copy" / "Copied!" with inline SVG icons (clipboard icon → checkmark icon on click, reverts after 1.5s)
- **Positioning**: Changed from `position: fixed` on `document.body` to `position: absolute` within the editor wrapper. This keeps the button anchored to the top-right corner of the code block during scroll without needing manual scroll listeners
- **Performance**: Removed the `cloneNode(true)` + `replaceChild` pattern on every hover. The button is created once and visibility toggles via CSS opacity
- **Theme support**: Added light mode (white semi-transparent bg, dark text) and dark mode (dark semi-transparent bg, light text) styles. Icon uses `currentColor` so it tracks the theme automatically
- **Accessibility**: Added `aria-label="Copy code"` to the button
- **Error handling**: Clipboard failures are now logged instead of silently swallowed

### Files Changed

- `packages/web/src/hooks/useMilkdown.ts` — Rewrote copy button creation, positioning, and interaction
- `packages/web/src/components/editor/editor.css` — Added theme-compliant CSS for the floating button