### PR TITLE
fix(web): prevent code block background collision in dark mode

### DIFF
--- a/packages/web/src/components/editor/editor.css
+++ b/packages/web/src/components/editor/editor.css
@@ -171,6 +171,11 @@
   background-color: #374151;
 }
 
+.dark .milkdown-editor-view pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
 .dark .milkdown-editor-view a {
   color: #60a5fa;
 }


### PR DESCRIPTION
The dark mode `code` background rule (`.dark .milkdown-editor-view code`) was overriding the `pre code` transparency rule (`.milkdown-editor-view pre code`) due to higher CSS specificity (2 classes + 1 element vs 1 class + 2 elements). This caused `<code>` elements inside fenced code blocks to render with a separate background (`#374151`) on top of the `<pre>`'s background (`#111827`), creating a visually fragmented appearance in dark mode.

Added `.dark .milkdown-editor-view pre code` with specificity (2 classes + 2 elements) to restore transparency for code inside pre blocks in dark mode, matching the light mode behavior.

Fixes #24