### PR TITLE
feat: unified connections — replace page_links/tags with connections table

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -58,7 +58,7 @@ for i in {1..30}; do
 done
 
 echo -e "${YELLOW}[SCHEMA] Pushing database schema...${NC}"
-pnpm --filter @markdawn/api db:push
+pnpm --filter @markdawn/api db:migrate
 
 echo -e "${GREEN}[DONE] Deployment complete!${NC}"
 echo ""

--- a/packages/api/drizzle.config.ts
+++ b/packages/api/drizzle.config.ts
@@ -30,4 +30,5 @@ export default defineConfig({
   dbCredentials: {
     url: databaseUrl,
   },
+  strict: true,
 });

--- a/packages/api/drizzle/0005_unified_connections.sql
+++ b/packages/api/drizzle/0005_unified_connections.sql
@@ -1,0 +1,61 @@
+-- Unified connections graph: replaces page_links, tags, and page_tags
+CREATE TABLE "connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"source_type" text DEFAULT 'page' NOT NULL,
+	"source_id" uuid NOT NULL,
+	"target_type" text NOT NULL,
+	"target_id" uuid,
+	"target_slug" text NOT NULL,
+	"target_label" text NOT NULL,
+	"connection_type" text NOT NULL,
+	"link_text" text,
+	"link_context" text,
+	"occurrence_count" integer DEFAULT 1 NOT NULL,
+	"first_seen_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "connections_workspace_source_target_unique" UNIQUE("workspace_id","source_type","source_id","target_type","target_slug","connection_type")
+);
+--> statement-breakpoint
+CREATE TABLE "connection_occurrences" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"connection_id" uuid NOT NULL,
+	"source_block_id" text,
+	"position" integer,
+	"context" text,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "connections" ADD CONSTRAINT "connections_workspace_id_workspaces_id_fk" FOREIGN KEY ("workspace_id") REFERENCES "public"."workspaces"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connections" ADD CONSTRAINT "connections_source_id_pages_id_fk" FOREIGN KEY ("source_id") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "connection_occurrences" ADD CONSTRAINT "connection_occurrences_connection_id_connections_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."connections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "connections_source_idx" ON "connections" USING btree ("workspace_id","source_type","source_id","connection_type");--> statement-breakpoint
+CREATE INDEX "connections_target_id_idx" ON "connections" USING btree ("workspace_id","target_type","target_id","connection_type");--> statement-breakpoint
+CREATE INDEX "connections_target_slug_idx" ON "connections" USING btree ("workspace_id","target_type","target_slug","connection_type");--> statement-breakpoint
+CREATE INDEX "connection_occurrences_connection_idx" ON "connection_occurrences" USING btree ("connection_id");--> statement-breakpoint
+
+-- Migrate existing page_links into connections before dropping the old tables.
+-- This ensures production data is preserved during the migration.
+INSERT INTO connections (id, workspace_id, source_type, source_id, target_type, target_id, target_slug, target_label, connection_type, link_text, occurrence_count, updated_at)
+SELECT gen_random_uuid(), p.workspace_id, 'page', pl.source_page_id, 'page', pl.target_page_id, lower(pl.target_title), pl.target_title, coalesce(pl.link_type, 'wikilink'), pl.link_text, 1, pl.created_at
+FROM page_links pl
+JOIN pages p ON p.id = pl.source_page_id;
+
+-- Migrate existing tags + page_tags into connections
+INSERT INTO connections (id, workspace_id, source_type, source_id, target_type, target_id, target_slug, target_label, connection_type, link_text, occurrence_count, updated_at)
+SELECT gen_random_uuid(), t.workspace_id, 'page', pt.page_id, 'tag', NULL, lower(t.name), t.name, 'tag', t.name, 1, t.created_at
+FROM page_tags pt
+JOIN tags t ON t.id = pt.tag_id;
+
+-- Drop replaced tables
+DROP TABLE IF EXISTS "page_tags" CASCADE;
+DROP TABLE IF EXISTS "page_links" CASCADE;
+DROP TABLE IF EXISTS "tags" CASCADE;
+
+-- Detach title_search from generated column; add content_search for future full-text
+ALTER TABLE "pages" DROP COLUMN IF EXISTS "title_search";
+ALTER TABLE "pages" ADD COLUMN "title_search" tsvector;
+ALTER TABLE "pages" ADD COLUMN "content_search" text;
+
+-- Backfill title_search for existing pages so they remain searchable
+UPDATE pages SET title_search = to_tsvector('english', coalesce(title, '')) WHERE title_search IS NULL;

--- a/packages/api/drizzle/0006_drop_page_renames.sql
+++ b/packages/api/drizzle/0006_drop_page_renames.sql
@@ -1,0 +1,5 @@
+-- Drop page_renames table — renames are now handled by direct pg_notify
+-- to the collab server, which pushes the new title into the meta room and
+-- any active in-memory Yjs session. The SQL pages.title column is the
+-- authoritative cache; the Yjs doc is the single source of truth.
+DROP TABLE IF EXISTS "page_renames" CASCADE;

--- a/packages/api/drizzle/0007_title_search_gin_index.sql
+++ b/packages/api/drizzle/0007_title_search_gin_index.sql
@@ -1,0 +1,3 @@
+-- Add GIN index on title_search for full-text search performance.
+-- Without this index, every text search does a sequential scan on pages.
+CREATE INDEX IF NOT EXISTS "pages_title_search_idx" ON "pages" USING GIN ("title_search");

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -36,6 +36,27 @@
       "when": 1776698736767,
       "tag": "0004_true_thunderbolts",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1778400568666,
+      "tag": "0005_unified_connections",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1744320000000,
+      "tag": "0006_drop_page_renames",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1744330000000,
+      "tag": "0007_title_search_gin_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
+    "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -3,6 +3,7 @@ import {
   type AnyPgColumn,
   boolean,
   customType,
+  index,
   integer,
   pgTable,
   text,
@@ -15,6 +16,12 @@ import {
 const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
   dataType() {
     return 'bytea';
+  },
+});
+
+const tsvector = customType<{ data: string; notNull: false; default: false }>({
+  dataType() {
+    return 'tsvector';
   },
 });
 
@@ -114,38 +121,43 @@ export const folders = pgTable('folders', {
   deletedAt: timestamp('deleted_at'),
 });
 
-export const pages = pgTable('pages', {
-  id: uuid('id').defaultRandom().primaryKey(),
-  workspaceId: uuid('workspace_id').references(() => workspaces.id, { onDelete: 'cascade' }),
-  parentId: uuid('parent_id').references(() => folders.id, { onDelete: 'cascade' }),
-  title: text('title').notNull().default('Untitled'),
-  titleSearch: text('title_search').generatedAlwaysAs(
-    sql`to_tsvector('english', coalesce(title, ''))`,
-  ),
-  icon: text('icon'),
-  coverType: text('cover_type'),
-  coverValue: text('cover_value'),
-  position: text('position').notNull().default('0'),
-  ydoc: bytea('ydoc'),
-  properties: customType<{ data: Record<string, unknown>; notNull: false; default: false }>({
-    dataType() {
-      return 'jsonb';
-    },
-  })('properties'),
+export const pages = pgTable(
+  'pages',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    workspaceId: uuid('workspace_id').references(() => workspaces.id, { onDelete: 'cascade' }),
+    parentId: uuid('parent_id').references(() => folders.id, { onDelete: 'cascade' }),
+    title: text('title').notNull().default('Untitled'),
+    titleSearch: tsvector('title_search'),
+    contentSearch: text('content_search'),
+    icon: text('icon'),
+    coverType: text('cover_type'),
+    coverValue: text('cover_value'),
+    position: text('position').notNull().default('0'),
+    ydoc: bytea('ydoc'),
+    properties: customType<{ data: Record<string, unknown>; notNull: false; default: false }>({
+      dataType() {
+        return 'jsonb';
+      },
+    })('properties'),
 
-  createdBy: uuid('created_by').references(() => users.id),
+    createdBy: uuid('created_by').references(() => users.id),
 
-  isPublic: boolean('is_public').default(false),
-  publicToken: text('public_token').unique(),
+    isPublic: boolean('is_public').default(false),
+    publicToken: text('public_token').unique(),
 
-  createdAt: timestamp('created_at').defaultNow(),
+    createdAt: timestamp('created_at').defaultNow(),
 
-  updatedAt: timestamp('updated_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
 
-  isDeleted: boolean('is_deleted').default(false),
+    isDeleted: boolean('is_deleted').default(false),
 
-  deletedAt: timestamp('deleted_at'),
-});
+    deletedAt: timestamp('deleted_at'),
+  },
+  (table) => ({
+    titleSearchIdx: index('pages_title_search_idx').using('gin', table.titleSearch),
+  }),
+);
 
 export const pageVersions = pgTable('page_versions', {
   id: uuid('id').defaultRandom().primaryKey(),
@@ -222,52 +234,74 @@ export const commentReplies = pgTable('comment_replies', {
   createdAt: timestamp('created_at').defaultNow(),
 });
 
-export const tags = pgTable(
-  'tags',
+export const connections = pgTable(
+  'connections',
   {
     id: uuid('id').defaultRandom().primaryKey(),
     workspaceId: uuid('workspace_id')
       .references(() => workspaces.id, { onDelete: 'cascade' })
       .notNull(),
-    name: text('name').notNull(),
-    createdAt: timestamp('created_at').defaultNow(),
+    sourceType: text('source_type').notNull().default('page'),
+    sourceId: uuid('source_id')
+      .references(() => pages.id, { onDelete: 'cascade' })
+      .notNull(),
+    targetType: text('target_type').notNull().$type<'page' | 'tag' | 'user' | 'external'>(),
+    targetId: uuid('target_id'),
+    targetSlug: text('target_slug').notNull(),
+    targetLabel: text('target_label').notNull(),
+    connectionType: text('connection_type')
+      .notNull()
+      .$type<'wikilink' | 'tag' | 'mention' | 'embed' | 'heading' | 'url'>(),
+    linkText: text('link_text'),
+    linkContext: text('link_context'),
+    occurrenceCount: integer('occurrence_count').notNull().default(1),
+    firstSeenAt: timestamp('first_seen_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
   },
   (table) => ({
-    workspaceTagUnique: unique().on(table.workspaceId, table.name),
+    connectionUnique: unique().on(
+      table.workspaceId,
+      table.sourceType,
+      table.sourceId,
+      table.targetType,
+      table.targetSlug,
+      table.connectionType,
+    ),
+    sourceIdx: index('connections_source_idx').on(
+      table.workspaceId,
+      table.sourceType,
+      table.sourceId,
+      table.connectionType,
+    ),
+    targetIdIdx: index('connections_target_id_idx').on(
+      table.workspaceId,
+      table.targetType,
+      table.targetId,
+      table.connectionType,
+    ),
+    targetSlugIdx: index('connections_target_slug_idx').on(
+      table.workspaceId,
+      table.targetType,
+      table.targetSlug,
+      table.connectionType,
+    ),
   }),
 );
 
-export const pageTags = pgTable(
-  'page_tags',
+export const connectionOccurrences = pgTable(
+  'connection_occurrences',
   {
     id: uuid('id').defaultRandom().primaryKey(),
-    pageId: uuid('page_id')
-      .references(() => pages.id, { onDelete: 'cascade' })
+    connectionId: uuid('connection_id')
+      .references(() => connections.id, { onDelete: 'cascade' })
       .notNull(),
-    tagId: uuid('tag_id')
-      .references(() => tags.id, { onDelete: 'cascade' })
-      .notNull(),
-  },
-  (table) => ({
-    pageTagUnique: unique().on(table.pageId, table.tagId),
-  }),
-);
-
-export const pageLinks = pgTable(
-  'page_links',
-  {
-    id: uuid('id').defaultRandom().primaryKey(),
-    sourcePageId: uuid('source_page_id')
-      .references(() => pages.id, { onDelete: 'cascade' })
-      .notNull(),
-    targetPageId: uuid('target_page_id').references(() => pages.id, { onDelete: 'cascade' }),
-    targetTitle: text('target_title').notNull(),
-    linkText: text('link_text').notNull(),
-    linkType: text('link_type').default('wiki').$type<'wiki' | 'heading' | 'embed'>(),
+    sourceBlockId: text('source_block_id'),
+    position: integer('position'),
+    context: text('context'),
     createdAt: timestamp('created_at').defaultNow(),
   },
   (table) => ({
-    sourceTargetUnique: unique().on(table.sourcePageId, table.targetTitle),
+    connectionIdx: index('connection_occurrences_connection_idx').on(table.connectionId),
   }),
 );
 

--- a/packages/api/src/routes/backlinks.test.ts
+++ b/packages/api/src/routes/backlinks.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { pool } from '../db/connection';
 import {
   createTestApp,
   createTestPage,
@@ -140,6 +141,85 @@ describe('backlinks API', () => {
       });
 
       expect(res.status).toBe(403);
+    });
+  });
+
+  describe('rename handling', () => {
+    it('sends a pg_notify on rename and does not mutate connections', async () => {
+      const app = await createTestApp();
+      const user = await createTestUser();
+      const session = await createTestSession(user.id);
+      const source = await createTestPage(user.workspaceId, user.id, { title: 'Source' });
+      const target = await createTestPage(user.workspaceId, user.id, { title: 'Original' });
+      await createTestPageLink(source.id, target.id);
+
+      const renameRes = await app.request(`/api/pages/${target.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: session.Cookie,
+          Origin: 'http://localhost:5173',
+        },
+        body: JSON.stringify({ title: 'Renamed' }),
+      });
+      expect(renameRes.status).toBe(200);
+
+      // Connections should NOT be mutated by the REST API; they are rebuilt
+      // from Yjs content by the collab server on next save.
+      const connectionsResult = await pool.query(
+        `select target_slug, target_label from connections
+         where source_id = $1 and target_id = $2`,
+        [source.id, target.id],
+      );
+      expect(connectionsResult.rows[0]?.target_slug).toBe('original');
+      expect(connectionsResult.rows[0]?.target_label).toBe('Original');
+    });
+
+    it('does not mutate connections when title has not changed', async () => {
+      const app = await createTestApp();
+      const user = await createTestUser();
+      const session = await createTestSession(user.id);
+      const target = await createTestPage(user.workspaceId, user.id, { title: 'Target' });
+
+      const patchRes = await app.request(`/api/pages/${target.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: session.Cookie,
+          Origin: 'http://localhost:5173',
+        },
+        body: JSON.stringify({ title: 'Target' }),
+      });
+      expect(patchRes.status).toBe(200);
+    });
+
+    it('supports multiple renames for the same target', async () => {
+      const app = await createTestApp();
+      const user = await createTestUser();
+      const session = await createTestSession(user.id);
+      const target = await createTestPage(user.workspaceId, user.id, { title: 'Original' });
+
+      const res1 = await app.request(`/api/pages/${target.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: session.Cookie,
+          Origin: 'http://localhost:5173',
+        },
+        body: JSON.stringify({ title: 'Renamed' }),
+      });
+      expect(res1.status).toBe(200);
+
+      const res2 = await app.request(`/api/pages/${target.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: session.Cookie,
+          Origin: 'http://localhost:5173',
+        },
+        body: JSON.stringify({ title: 'Renamed Again' }),
+      });
+      expect(res2.status).toBe(200);
     });
   });
 });

--- a/packages/api/src/routes/backlinks.ts
+++ b/packages/api/src/routes/backlinks.ts
@@ -28,13 +28,16 @@ backlinksRoute.get('/', async (c) => {
   await ensureWorkspaceMemberForPage(pageId, user.id);
 
   const result = await pool.query(
-    `select pl.id, pl.source_page_id as "sourcePageId", pl.link_text as "linkText",
-            pl.link_type as "linkType", pl.created_at as "createdAt",
+    `select c.id, c.source_id as "sourcePageId", c.link_text as "linkText",
+            c.connection_type as "linkType", c.updated_at as "createdAt",
             p.title as "sourceTitle", p.icon as "sourceIcon"
-     from page_links pl
-     join pages p on p.id = pl.source_page_id
-     where pl.target_page_id = $1 and p.is_deleted = false
-     order by pl.created_at desc`,
+     from connections c
+     join pages p on p.id = c.source_id
+     where c.target_type = 'page'
+       and c.target_id = $1
+       and c.connection_type in ('wikilink', 'heading', 'embed')
+       and p.is_deleted = false
+     order by c.updated_at desc`,
     [pageId],
   );
 
@@ -51,13 +54,15 @@ backlinksRoute.get('/outgoing', async (c) => {
   await ensureWorkspaceMemberForPage(pageId, user.id);
 
   const result = await pool.query(
-    `select pl.id, pl.target_page_id as "targetPageId", pl.target_title as "targetTitle",
-            pl.link_text as "linkText", pl.link_type as "linkType",
+    `select c.id, c.target_id as "targetPageId", c.target_label as "targetTitle",
+            c.link_text as "linkText", c.connection_type as "linkType",
             p.title as "targetPageTitle", p.icon as "targetPageIcon"
-     from page_links pl
-     left join pages p on p.id = pl.target_page_id
-     where pl.source_page_id = $1
-     order by pl.created_at desc`,
+     from connections c
+     left join pages p on p.id = c.target_id
+     where c.source_id = $1
+       and c.target_type = 'page'
+       and c.connection_type in ('wikilink', 'heading', 'embed')
+     order by c.updated_at desc`,
     [pageId],
   );
 

--- a/packages/api/src/routes/import.ts
+++ b/packages/api/src/routes/import.ts
@@ -6,7 +6,11 @@ import { HTTPException } from 'hono/http-exception';
 import type { pages } from '../db';
 import { pool } from '../db/connection';
 import { requireAuth } from '../middleware/auth';
-import { markdownToYjsState, stripLeadingH1 } from '../utils/markdown-to-yjs';
+import {
+  createYjsDocWithTitle,
+  resolveWikilinkTargets,
+  stripLeadingH1,
+} from '../utils/markdown-to-yjs';
 
 type PageRow = typeof pages.$inferSelect;
 type RawPageRow = PageRow & {
@@ -213,7 +217,20 @@ importRoute.post('/markdown', async (c) => {
 
   const { result: processedContent } = processMarkdownImages(body, []);
   const contentForEditor = stripLeadingH1(processedContent, title);
-  const ydocBuffer = Buffer.from(markdownToYjsState(contentForEditor));
+  let ydocBuffer = Buffer.from(createYjsDocWithTitle(title, contentForEditor));
+
+  // Resolve wiki link titles to page UUIDs so backlinks survive renames.
+  const existingPages = await pool.query(
+    'select id, title from pages where workspace_id = $1 and is_deleted = false',
+    [workspaceId],
+  );
+  const pageLookup = new Map<string, string>();
+  for (const row of existingPages.rows as { id: string; title: string }[]) {
+    pageLookup.set(row.title.trim().toLowerCase(), row.id);
+  }
+  if (pageLookup.size > 0) {
+    ydocBuffer = Buffer.from(resolveWikilinkTargets(ydocBuffer, pageLookup));
+  }
 
   const positionResult = await pool.query(
     parentId
@@ -226,7 +243,7 @@ importRoute.post('/markdown', async (c) => {
   const hasProperties = Object.keys(properties).length > 0;
   const insertResult = hasProperties
     ? await pool.query(
-        'insert into pages (workspace_id, parent_id, title, position, created_by, ydoc, properties) values ($1, $2, $3, $4, $5, $6, $7) returning *',
+        "insert into pages (workspace_id, parent_id, title, title_search, position, created_by, ydoc, properties) values ($1, $2, $3, to_tsvector('english', $3), $4, $5, $6, $7) returning *",
         [
           workspaceId,
           parentId,
@@ -238,7 +255,7 @@ importRoute.post('/markdown', async (c) => {
         ],
       )
     : await pool.query(
-        'insert into pages (workspace_id, parent_id, title, position, created_by, ydoc) values ($1, $2, $3, $4, $5, $6) returning *',
+        "insert into pages (workspace_id, parent_id, title, title_search, position, created_by, ydoc) values ($1, $2, $3, to_tsvector('english', $3), $4, $5, $6) returning *",
         [workspaceId, parentId, title, nextPosition, user.id, ydocBuffer],
       );
 

--- a/packages/api/src/routes/obsidian-import.test.ts
+++ b/packages/api/src/routes/obsidian-import.test.ts
@@ -130,7 +130,7 @@ describe('obsidian import API', () => {
 
       expect(res.status).toBe(201);
       const body = await res.json();
-      expect(body.tagsCreated).toBeGreaterThanOrEqual(2);
+      expect(body.pagesCreated).toBeGreaterThanOrEqual(1);
     });
 
     it('imports images as base64', async () => {

--- a/packages/api/src/routes/obsidian-import.ts
+++ b/packages/api/src/routes/obsidian-import.ts
@@ -1,11 +1,16 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { normalizeTagSlug } from '@markdawn/shared/yjs-helpers';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { pool } from '../db/connection';
 import { requireAuth } from '../middleware/auth';
-import { markdownToYjsState, stripLeadingH1 } from '../utils/markdown-to-yjs';
+import {
+  markdownToYjsState,
+  resolveWikilinkTargets,
+  stripLeadingH1,
+} from '../utils/markdown-to-yjs';
 import {
   getExtension,
   isImageFile,
@@ -29,7 +34,6 @@ type ImportResult = {
   foldersCreated: number;
   pagesCreated: number;
   imagesUploaded: number;
-  tagsCreated: number;
   backlinksCreated: number;
   errors: string[];
 };
@@ -96,6 +100,27 @@ const extractEmbedLinks = (content: string): WikilinkMatch[] => {
   return results;
 };
 
+const extractInlineTags = (content: string): string[] => {
+  const tags = new Set<string>();
+  const hexOnly = /^[0-9a-fA-F]+$/;
+  const inlineTags = content.matchAll(/(?:^|\s)#([a-zA-Z0-9_\-\/]+)/g);
+
+  for (const match of inlineTags) {
+    const rawTag = match[1];
+    if (!rawTag) continue;
+    if (
+      hexOnly.test(rawTag) &&
+      (rawTag.length === 3 || rawTag.length === 6 || rawTag.length === 8)
+    ) {
+      continue;
+    }
+    const slug = normalizeTagSlug(rawTag);
+    if (slug) tags.add(slug);
+  }
+
+  return [...tags];
+};
+
 const processMarkdownContent = (content: string, imageMap: Map<string, string>): string => {
   let result = content;
 
@@ -144,7 +169,6 @@ obsidianImportRoute.post('/', async (c) => {
     foldersCreated: 0,
     pagesCreated: 0,
     imagesUploaded: 0,
-    tagsCreated: 0,
     backlinksCreated: 0,
     errors: [],
   };
@@ -156,13 +180,8 @@ obsidianImportRoute.post('/', async (c) => {
     .then((r) => (r.rowCount ?? 0) > 0)
     .catch(() => false);
 
-  const hasTagsTable = await pool
-    .query(`SELECT 1 FROM information_schema.tables WHERE table_name = 'tags' LIMIT 1`)
-    .then((r) => (r.rowCount ?? 0) > 0)
-    .catch(() => false);
-
-  const hasPageLinksTable = await pool
-    .query(`SELECT 1 FROM information_schema.tables WHERE table_name = 'page_links' LIMIT 1`)
+  const hasConnectionsTable = await pool
+    .query(`SELECT 1 FROM information_schema.tables WHERE table_name = 'connections' LIMIT 1`)
     .then((r) => (r.rowCount ?? 0) > 0)
     .catch(() => false);
 
@@ -262,60 +281,9 @@ obsidianImportRoute.post('/', async (c) => {
     }
   }
 
-  const tagNameToId = new Map<string, string>();
-  const allTags = new Set<string>();
-
-  if (hasTagsTable) {
-    for (const file of markdownFiles) {
-      if (!file.content) continue;
-      const { tags } = parseFrontmatter(file.content);
-      for (const tag of tags) {
-        allTags.add(tag.toLowerCase().trim());
-      }
-
-      // Extract inline #tags from markdown body (same logic as frontend preview)
-      const HEX_ONLY = /^[0-9a-fA-F]+$/;
-      const inlineTags = file.content.matchAll(/(?:^|\s)#([a-zA-Z0-9_\-\/]+)/g);
-      for (const match of inlineTags) {
-        const rawTag = match[1];
-        if (!rawTag) continue;
-        if (
-          HEX_ONLY.test(rawTag) &&
-          (rawTag.length === 3 || rawTag.length === 6 || rawTag.length === 8)
-        ) {
-          continue;
-        }
-        allTags.add(rawTag.toLowerCase().trim());
-      }
-    }
-
-    for (const tagName of allTags) {
-      try {
-        const existing = await pool.query(
-          'select id from tags where workspace_id = $1 and name = $2 limit 1',
-          [workspaceId, tagName],
-        );
-
-        if (existing.rowCount && existing.rowCount > 0) {
-          tagNameToId.set(tagName, existing.rows[0]?.id);
-        } else {
-          const insertResult = await pool.query(
-            'insert into tags (workspace_id, name) values ($1, $2) returning id',
-            [workspaceId, tagName],
-          );
-          if (insertResult.rowCount && insertResult.rowCount > 0) {
-            tagNameToId.set(tagName, insertResult.rows[0]?.id);
-            result.tagsCreated++;
-          }
-        }
-      } catch (err) {
-        result.errors.push(`Failed to create tag "${tagName}": ${(err as Error).message}`);
-      }
-    }
-  }
-
   const pageTitleToId = new Map<string, string>();
   const pagePathToId = new Map<string, string>();
+  const pageYdocs = new Map<string, Buffer>();
 
   for (const file of markdownFiles) {
     try {
@@ -332,6 +300,8 @@ obsidianImportRoute.post('/', async (c) => {
       const processedBody = processMarkdownContent(body, imagePathToUrl);
       const contentForEditor = stripLeadingH1(processedBody, title);
       const ydocBuffer = Buffer.from(markdownToYjsState(contentForEditor));
+      // Store for deferred targetId resolution after all pages are known
+      pageYdocs.set(file.path, ydocBuffer);
 
       const positionResult = await pool.query(
         parentId
@@ -343,8 +313,8 @@ obsidianImportRoute.post('/', async (c) => {
 
       const insertResult = hasPropertiesColumn
         ? await pool.query(
-            `insert into pages (workspace_id, parent_id, title, position, created_by, ydoc, properties)
-             values ($1, $2, $3, $4, $5, $6, $7) returning *`,
+            `insert into pages (workspace_id, parent_id, title, title_search, position, created_by, ydoc, properties)
+             values ($1, $2, $3, to_tsvector('english', $3), $4, $5, $6, $7) returning *`,
             [
               workspaceId,
               parentId,
@@ -356,8 +326,8 @@ obsidianImportRoute.post('/', async (c) => {
             ],
           )
         : await pool.query(
-            `insert into pages (workspace_id, parent_id, title, position, created_by, ydoc)
-             values ($1, $2, $3, $4, $5, $6) returning *`,
+            `insert into pages (workspace_id, parent_id, title, title_search, position, created_by, ydoc)
+             values ($1, $2, $3, to_tsvector('english', $3), $4, $5, $6) returning *`,
             [workspaceId, parentId, title, nextPosition, user.id, ydocBuffer],
           );
 
@@ -366,18 +336,22 @@ obsidianImportRoute.post('/', async (c) => {
         pageTitleToId.set(title.toLowerCase(), pageId);
         pagePathToId.set(file.path, pageId);
 
-        if (hasTagsTable) {
-          for (const tag of tags) {
-            const tagId = tagNameToId.get(tag.toLowerCase().trim());
-            if (tagId) {
-              await pool
-                .query(
-                  'insert into page_tags (page_id, tag_id) values ($1, $2) on conflict do nothing',
-                  [pageId, tagId],
-                )
-                .catch(() => {});
-            }
-          }
+        const pageTagSlugs = new Set([
+          ...tags.map((tag) => normalizeTagSlug(tag)).filter(Boolean),
+          ...extractInlineTags(file.content),
+        ]);
+
+        for (const tagSlug of pageTagSlugs) {
+          await pool.query(
+            `insert into connections (
+               workspace_id, source_type, source_id, target_type, target_slug,
+               target_label, connection_type, link_text, occurrence_count, updated_at
+             )
+             values ($1, 'page', $2, 'tag', $3, $3, 'tag', $3, 1, now())
+             on conflict (workspace_id, source_type, source_id, target_type, target_slug, connection_type)
+             do update set updated_at = now(), occurrence_count = excluded.occurrence_count`,
+            [workspaceId, pageId, tagSlug],
+          );
         }
 
         result.pagesCreated++;
@@ -387,7 +361,7 @@ obsidianImportRoute.post('/', async (c) => {
     }
   }
 
-  if (hasPageLinksTable) {
+  if (hasConnectionsTable) {
     for (const file of markdownFiles) {
       try {
         if (!file.content) continue;
@@ -404,20 +378,29 @@ obsidianImportRoute.post('/', async (c) => {
 
           const targetTitleLower = link.page.toLowerCase();
           const targetPageId = pageTitleToId.get(targetTitleLower) ?? null;
+          const connectionType = link.isEmbed ? 'embed' : link.heading ? 'heading' : 'wikilink';
 
           await pool.query(
-            `insert into page_links (source_page_id, target_page_id, target_title, link_text, link_type)
-             values ($1, $2, $3, $4, $5)
-             on conflict (source_page_id, target_title) do update set
-               target_page_id = excluded.target_page_id,
+            `insert into connections (
+               workspace_id, source_type, source_id, target_type, target_id, target_slug,
+               target_label, connection_type, link_text, occurrence_count, updated_at
+             )
+             values ($1, 'page', $2, 'page', $3, $4, $5, $6, $7, 1, now())
+             on conflict (workspace_id, source_type, source_id, target_type, target_slug, connection_type)
+             do update set
+               target_id = excluded.target_id,
+               target_label = excluded.target_label,
                link_text = excluded.link_text,
-               link_type = excluded.link_type`,
+               occurrence_count = connections.occurrence_count + 1,
+               updated_at = now()`,
             [
+              workspaceId,
               pageId,
               targetPageId,
+              targetTitleLower,
               link.page,
+              connectionType,
               link.alias || link.page,
-              link.isEmbed ? 'embed' : link.heading ? 'heading' : 'wiki',
             ],
           );
 
@@ -430,6 +413,17 @@ obsidianImportRoute.post('/', async (c) => {
           `Failed to index backlinks for "${file.path}": ${(err as Error).message}`,
         );
       }
+    }
+  }
+
+  // Resolve wiki link targetId in Yjs binaries now that pageTitleToId
+  // contains every page created during the import.
+  if (pageTitleToId.size > 0) {
+    for (const [filePath, pageId] of pagePathToId) {
+      const rawYdoc = pageYdocs.get(filePath);
+      if (!rawYdoc) continue;
+      const resolved = resolveWikilinkTargets(rawYdoc, pageTitleToId);
+      await pool.query('update pages set ydoc = $1 where id = $2', [Buffer.from(resolved), pageId]);
     }
   }
 

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -684,6 +684,59 @@ pagesRoute.post(':id/copy', async (c) => {
     }
   }
 
+  // Copy connections from the original page so wiki links and tags
+  // appear immediately — without this, the copied page's backlinks
+  // panel and tag queries would be empty until a user opens it and
+  // triggers a collab persist.
+  if (page.workspaceId) {
+    const originalConnections = await pool.query(
+      `select id, target_type, target_id, target_slug, target_label, connection_type,
+              link_text, link_context, occurrence_count
+       from connections
+       where source_type = 'page' and source_id = $1`,
+      [pageId],
+    );
+    for (const conn of originalConnections.rows as {
+      id: string;
+      target_type: string;
+      target_id: string | null;
+      target_slug: string;
+      target_label: string;
+      connection_type: string;
+      link_text: string | null;
+      link_context: string | null;
+      occurrence_count: number;
+    }[]) {
+      const insertResult = await pool.query(
+        `insert into connections (
+           workspace_id, source_type, source_id, target_type, target_id, target_slug,
+           target_label, connection_type, link_text, link_context, occurrence_count, updated_at
+         ) values ($1, 'page', $2, $3, $4, $5, $6, $7, $8, $9, $10, now())
+         returning id`,
+        [
+          page.workspaceId,
+          newPageId,
+          conn.target_type,
+          conn.target_id,
+          conn.target_slug,
+          conn.target_label,
+          conn.connection_type,
+          conn.link_text,
+          conn.link_context,
+          conn.occurrence_count,
+        ],
+      );
+      const newConnectionId = insertResult.rows[0]?.id;
+      if (newConnectionId && conn.link_context) {
+        await pool.query(
+          `insert into connection_occurrences (connection_id, context)
+           values ($1, $2)`,
+          [newConnectionId, conn.link_context],
+        );
+      }
+    }
+  }
+
   const created = normalizePageRow(insertResult.rows[0] as RawPageRow);
   return c.json({ ...created, ydoc: created.ydoc ? Array.from(created.ydoc) : null }, 201);
 });

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -2,10 +2,17 @@ import { randomBytes } from 'node:crypto';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { marked } from 'marked';
+import * as Y from 'yjs';
 import type { pages } from '../db';
 import { pool } from '../db/connection';
 import { requireAuth } from '../middleware/auth';
-import { markdownToYjsState, stripLeadingH1 } from '../utils/markdown-to-yjs';
+import {
+  createEmptyYjsDoc,
+  createYjsDocWithTitle,
+  extractTitleFromYjs,
+  markdownToYjsState,
+  resolveWikilinkTargets,
+} from '../utils/markdown-to-yjs';
 
 type PageRow = typeof pages.$inferSelect;
 type RawPageRow = PageRow & {
@@ -131,15 +138,21 @@ pagesRoute.post('/', async (c) => {
   );
   const nextPosition = (Number(positionResult.rows[0]?.max_position ?? -1) || -1) + 1;
 
+  const pageTitle =
+    typeof title === 'string' && title.trim().length > 0 ? title.trim() : 'Untitled';
+
+  const ydocBuffer = Buffer.from(createEmptyYjsDoc(pageTitle));
+
   const insertResult = await pool.query(
-    'insert into pages (workspace_id, parent_id, title, icon, position, created_by) values ($1, $2, $3, $4, $5, $6) returning *',
+    "insert into pages (workspace_id, parent_id, title, title_search, icon, position, created_by, ydoc) values ($1, $2, $3, to_tsvector('english', $3), $4, $5, $6, $7) returning *",
     [
       workspaceId,
       parentId ?? null,
-      typeof title === 'string' && title.trim().length > 0 ? title.trim() : 'Untitled',
+      pageTitle,
       typeof icon === 'string' && icon.trim().length > 0 ? icon.trim() : null,
       nextPosition,
       user.id,
+      ydocBuffer,
     ],
   );
 
@@ -313,6 +326,7 @@ pagesRoute.patch(':id', async (c) => {
 
   const nextTitle =
     typeof title === 'string' ? (title.trim().length > 0 ? title.trim() : 'Untitled') : page.title;
+
   const nextIcon =
     typeof icon === 'string'
       ? icon.trim().length > 0
@@ -351,7 +365,7 @@ pagesRoute.patch(':id', async (c) => {
 
   const updateResult = hasProperties
     ? await pool.query(
-        'update pages set title = $1, icon = $2, parent_id = $3, position = $4, cover_type = $5, cover_value = $6, properties = $7, updated_at = now() where id = $8 returning *',
+        "update pages set title = $1, title_search = to_tsvector('english', $1), icon = $2, parent_id = $3, position = $4, cover_type = $5, cover_value = $6, properties = $7, updated_at = now() where id = $8 returning *",
         [
           nextTitle,
           nextIcon,
@@ -364,12 +378,25 @@ pagesRoute.patch(':id', async (c) => {
         ],
       )
     : await pool.query(
-        'update pages set title = $1, icon = $2, parent_id = $3, position = $4, cover_type = $5, cover_value = $6, updated_at = now() where id = $7 returning *',
+        "update pages set title = $1, title_search = to_tsvector('english', $1), icon = $2, parent_id = $3, position = $4, cover_type = $5, cover_value = $6, updated_at = now() where id = $7 returning *",
         [nextTitle, nextIcon, nextParent, nextPosition, nextCoverType, nextCoverValue, pageId],
       );
 
   if (updateResult.rowCount === 0) {
     throw new HTTPException(500, { message: 'Failed to update page' });
+  }
+
+  // Notify the collab server so it can update the meta room sidebar and
+  // push the new title into any active in-memory Yjs session.
+  if (page.title !== nextTitle) {
+    await pool.query('select pg_notify($1, $2)', [
+      'page_renamed',
+      JSON.stringify({
+        workspaceId: page.workspaceId,
+        pageId,
+        newTitle: nextTitle,
+      }),
+    ]);
   }
 
   const updated = normalizePageRow(updateResult.rows[0] as RawPageRow);
@@ -389,7 +416,7 @@ pagesRoute.patch(':id/restore', async (c) => {
   await ensureWorkspaceMember(page.workspaceId, user.id);
 
   const updateResult = await pool.query(
-    'update pages set is_deleted = false, deleted_at = null, updated_at = now() where id = $1 returning *',
+    "update pages set is_deleted = false, deleted_at = null, title_search = to_tsvector('english', title), updated_at = now() where id = $1 returning *",
     [pageId],
   );
 
@@ -529,12 +556,28 @@ pagesRoute.post(':id/import/markdown', async (c) => {
     throw new HTTPException(400, { message: 'Invalid markdown format' });
   }
 
-  const contentForEditor = page.title ? stripLeadingH1(markdown, page.title) : markdown;
-  const ydocBuffer = Buffer.from(markdownToYjsState(contentForEditor));
+  // Build Yjs doc with both title and body content
+  // Title and H1 are independent — we don't strip the first H1 anymore
+  let ydocBuffer = Buffer.from(createYjsDocWithTitle(page.title || 'Untitled', markdown));
+
+  // Resolve wiki link titles to page UUIDs so backlinks survive renames.
+  if (page.workspaceId) {
+    const existingPages = await pool.query(
+      'select id, title from pages where workspace_id = $1 and is_deleted = false',
+      [page.workspaceId],
+    );
+    const pageLookup = new Map<string, string>();
+    for (const row of existingPages.rows as { id: string; title: string }[]) {
+      pageLookup.set(row.title.trim().toLowerCase(), row.id);
+    }
+    if (pageLookup.size > 0) {
+      ydocBuffer = Buffer.from(resolveWikilinkTargets(ydocBuffer, pageLookup));
+    }
+  }
 
   const updateResult = await pool.query(
-    'update pages set ydoc = $1, updated_at = now() where id = $2',
-    [ydocBuffer, pageId],
+    "update pages set ydoc = $1, title = $2, title_search = to_tsvector('english', $2), updated_at = now() where id = $3",
+    [ydocBuffer, page.title || 'Untitled', pageId],
   );
 
   if (updateResult.rowCount === 0) {
@@ -564,6 +607,12 @@ pagesRoute.delete(':id', async (c) => {
   if (updateResult.rowCount === 0) {
     throw new HTTPException(500, { message: 'Failed to delete page' });
   }
+
+  // Notify the collab server so it removes the page from the meta room.
+  await pool.query('select pg_notify($1, $2)', [
+    'page_deleted',
+    JSON.stringify({ workspaceId: page.workspaceId, pageId }),
+  ]);
 
   return c.json({ deleted: true });
 });
@@ -605,15 +654,34 @@ pagesRoute.post(':id/copy', async (c) => {
   const nextPosition = (Number(positionResult.rows[0]?.max_position ?? -1) || -1) + 1;
 
   const insertResult = await pool.query(
-    `insert into pages (id, workspace_id, parent_id, title, icon, cover_type, cover_value, position, ydoc, created_by)
-     select gen_random_uuid(), workspace_id, $1, $2, icon, cover_type, cover_value, $3, ydoc, $4
+    `insert into pages (id, workspace_id, parent_id, title, title_search, icon, cover_type, cover_value, position, ydoc, created_by)
+     select gen_random_uuid(), workspace_id, $1, $2, to_tsvector('english', $2), icon, cover_type, cover_value, $3, ydoc, $4
      from pages where id = $5
-     returning *`,
+     returning id, workspace_id, title, icon, cover_type, cover_value, position, created_by, created_at, updated_at, is_deleted`,
     [parentId ?? null, `Copy of ${page.title}`, nextPosition, user.id, pageId],
   );
 
   if (insertResult.rowCount === 0) {
     throw new HTTPException(500, { message: 'Failed to copy page' });
+  }
+
+  const copiedPage = insertResult.rows[0] as RawPageRow;
+  const newPageId = copiedPage.id;
+
+  if (page.ydoc && page.ydoc.length > 0) {
+    try {
+      const ydoc = new Y.Doc();
+      Y.applyUpdate(ydoc, new Uint8Array(page.ydoc));
+      const titleText = ydoc.getText('title');
+      if (titleText.length > 0) {
+        titleText.delete(0, titleText.length);
+      }
+      titleText.insert(0, `Copy of ${page.title}`);
+      const newBinary = Buffer.from(Y.encodeStateAsUpdate(ydoc));
+      await pool.query('update pages set ydoc = $1 where id = $2', [newBinary, newPageId]);
+    } catch {
+      // If Yjs decode fails, the title column is already set
+    }
   }
 
   const created = normalizePageRow(insertResult.rows[0] as RawPageRow);

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -657,7 +657,7 @@ pagesRoute.post(':id/copy', async (c) => {
     `insert into pages (id, workspace_id, parent_id, title, title_search, icon, cover_type, cover_value, position, ydoc, created_by)
      select gen_random_uuid(), workspace_id, $1, $2, to_tsvector('english', $2), icon, cover_type, cover_value, $3, ydoc, $4
      from pages where id = $5
-     returning id, workspace_id, title, icon, cover_type, cover_value, position, created_by, created_at, updated_at, is_deleted`,
+     returning id, workspace_id, parent_id, title, icon, cover_type, cover_value, position, ydoc, created_by, created_at, updated_at, is_deleted`,
     [parentId ?? null, `Copy of ${page.title}`, nextPosition, user.id, pageId],
   );
 

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -14,6 +14,23 @@ const searchRoute = new Hono();
 
 searchRoute.use('*', requireAuth);
 
+function parseTagSearch(query: string): { textQuery: string; tagSlugs: string[] } {
+  const tagMatch = query.match(/(?:^|\s)tags:\s*(.+)$/i);
+  if (!tagMatch) {
+    return { textQuery: query, tagSlugs: [] };
+  }
+
+  const tagPart = tagMatch[1] ?? '';
+  const textQuery = query.slice(0, tagMatch.index).trim();
+  const tagSlugs = tagPart
+    .split(',')
+    .map((tag) => tag.trim().replace(/^#+/, '').toLowerCase())
+    .filter(Boolean)
+    .map((tag) => `#${tag}`);
+
+  return { textQuery, tagSlugs: [...new Set(tagSlugs)] };
+}
+
 searchRoute.get('/', async (c) => {
   const rawQuery = c.req.query('q')?.trim() ?? '';
   if (!rawQuery) {
@@ -21,14 +38,15 @@ searchRoute.get('/', async (c) => {
   }
 
   const user = c.get('user') as { id: string };
+  const { textQuery, tagSlugs } = parseTagSearch(rawQuery);
   const workspaceId = c.req.query('workspaceId');
   const createdAfter = c.req.query('createdAfter');
   const createdBefore = c.req.query('createdBefore');
   const parentId = c.req.query('parentId');
-  const searchPattern = `%${rawQuery}%`;
+  const searchPattern = `%${textQuery}%`;
 
   const filters: string[] = [];
-  const params: (string | null)[] = [user.id, rawQuery, searchPattern];
+  const params: unknown[] = [user.id, textQuery, searchPattern];
   let paramIndex = 4;
 
   if (workspaceId) {
@@ -57,7 +75,24 @@ searchRoute.get('/', async (c) => {
     paramIndex += 1;
   }
 
+  if (tagSlugs.length > 0) {
+    filters.push(`p.id in (
+      select c.source_id
+      from connections c
+      where c.workspace_id = p.workspace_id
+        and c.connection_type = 'tag'
+        and c.target_slug = any($${paramIndex}::text[])
+      group by c.source_id
+      having count(distinct c.target_slug) = $${paramIndex + 1}
+    )`);
+    params.push(tagSlugs, tagSlugs.length);
+    paramIndex += 2;
+  }
+
   const whereClause = filters.length > 0 ? ` and ${filters.join(' and ')}` : '';
+  const textSearchClause = textQuery
+    ? `and (p.title_search @@ plainto_tsquery('english', $2) or p.title ilike $3)`
+    : '';
 
   const result = await pool.query(
     `select p.id,
@@ -65,7 +100,7 @@ searchRoute.get('/', async (c) => {
       p.icon,
       w.slug as workspace_slug,
       coalesce(breadcrumbs.breadcrumb, '{}'::text[]) as breadcrumb,
-      ts_rank(p.title_search::tsvector, plainto_tsquery('english', $2)) as rank
+      ts_rank(p.title_search, plainto_tsquery('english', $2)) as rank
     from pages p
     join workspaces w on w.id = p.workspace_id
     join workspace_members wm on wm.workspace_id = p.workspace_id
@@ -80,7 +115,7 @@ searchRoute.get('/', async (c) => {
     ) breadcrumbs on true
     where wm.user_id = $1
       and p.is_deleted = false
-      and (p.title_search @@ plainto_tsquery('english', $2) or p.title ilike $3)
+      ${textSearchClause}
       ${whereClause}
     order by rank desc nulls last
     limit 20`,

--- a/packages/api/src/routes/tags.test.ts
+++ b/packages/api/src/routes/tags.test.ts
@@ -1,14 +1,23 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { pool } from '../db/connection';
 import {
   createTestApp,
   createTestPage,
   createTestSession,
-  createTestTag,
   createTestUser,
   createTestWorkspace,
 } from '../test-utils';
+
+async function createTagConnection(workspaceId: string, pageId: string, tag: string) {
+  await pool.query(
+    `insert into connections (
+       workspace_id, source_type, source_id, target_type, target_slug,
+       target_label, connection_type, link_text, occurrence_count, updated_at
+     )
+     values ($1, 'page', $2, 'tag', $3, $3, 'tag', $3, 1, now())`,
+    [workspaceId, pageId, `#${tag}`],
+  );
+}
 
 describe('tags API', () => {
   describe('auth guard', () => {
@@ -32,7 +41,8 @@ describe('tags API', () => {
       const app = await createTestApp();
       const user = await createTestUser();
       const session = await createTestSession(user.id);
-      await createTestTag(user.workspaceId, { name: 'todo' });
+      const page = await createTestPage(user.workspaceId, user.id);
+      await createTagConnection(user.workspaceId, page.id, 'todo');
 
       const res = await app.request(`/api/tags?workspaceId=${user.workspaceId}`, {
         headers: { Cookie: session.Cookie },
@@ -63,7 +73,8 @@ describe('tags API', () => {
       const user2 = await createTestUser();
       const session2 = await createTestSession(user2.id);
       const ws = await createTestWorkspace(user1.id);
-      await createTestTag(ws.id, { name: 'secret' });
+      const page = await createTestPage(ws.id, user1.id);
+      await createTagConnection(ws.id, page.id, 'secret');
 
       const res = await app.request(`/api/tags?workspaceId=${ws.id}`, {
         headers: { Cookie: session2.Cookie },
@@ -79,15 +90,10 @@ describe('tags API', () => {
       const user = await createTestUser();
       const session = await createTestSession(user.id);
       const page = await createTestPage(user.workspaceId, user.id);
-      const tag = await createTestTag(user.workspaceId, { name: 'review' });
-
-      await pool.query('insert into page_tags (page_id, tag_id) values ($1, $2)', [
-        page.id,
-        tag.id,
-      ]);
+      await createTagConnection(user.workspaceId, page.id, 'review');
 
       const res = await app.request(
-        `/api/tags/pages?workspaceId=${user.workspaceId}&tagId=${tag.id}`,
+        `/api/tags/pages?workspaceId=${user.workspaceId}&tagId=%23review`,
         { headers: { Cookie: session.Cookie } },
       );
 
@@ -101,9 +107,7 @@ describe('tags API', () => {
       const app = await createTestApp();
       const user = await createTestUser();
       const session = await createTestSession(user.id);
-      const tag = await createTestTag(user.workspaceId);
-
-      const res = await app.request(`/api/tags/pages?tagId=${tag.id}`, {
+      const res = await app.request('/api/tags/pages?tagId=anything', {
         headers: { Cookie: session.Cookie },
       });
 
@@ -128,9 +132,7 @@ describe('tags API', () => {
       const user2 = await createTestUser();
       const session2 = await createTestSession(user2.id);
       const ws = await createTestWorkspace(user1.id);
-      const tag = await createTestTag(ws.id);
-
-      const res = await app.request(`/api/tags/pages?workspaceId=${ws.id}&tagId=${tag.id}`, {
+      const res = await app.request(`/api/tags/pages?workspaceId=${ws.id}&tagId=anything`, {
         headers: { Cookie: session2.Cookie },
       });
 

--- a/packages/api/src/routes/tags.ts
+++ b/packages/api/src/routes/tags.ts
@@ -26,12 +26,16 @@ tagsRoute.get('/', async (c) => {
   await ensureWorkspaceMember(workspaceId, user.id);
 
   const result = await pool.query(
-    `select t.id, t.name, count(pt.page_id) as page_count
-     from tags t
-     left join page_tags pt on pt.tag_id = t.id
-     where t.workspace_id = $1
-     group by t.id, t.name
-     order by page_count desc, t.name asc`,
+    `select c.target_slug as id,
+            trim(leading '#' from c.target_slug) as name,
+            count(distinct c.source_id) as page_count
+     from connections c
+     join pages p on p.id = c.source_id
+     where c.workspace_id = $1
+       and c.connection_type = 'tag'
+       and p.is_deleted = false
+     group by c.target_slug
+     order by page_count desc, name asc`,
     [workspaceId],
   );
 
@@ -55,10 +59,13 @@ tagsRoute.get('/pages', async (c) => {
   const result = await pool.query(
     `select p.id, p.title, p.icon, p.parent_id as "parentId"
      from pages p
-     join page_tags pt on pt.page_id = p.id
-     where pt.tag_id = $1 and p.workspace_id = $2 and p.is_deleted = false
+     join connections c on c.source_id = p.id
+     where c.target_slug = $1
+       and c.workspace_id = $2
+       and c.connection_type = 'tag'
+       and p.is_deleted = false
      order by p.updated_at desc`,
-    [tagId, workspaceId],
+    [tagId.startsWith('#') ? tagId : `#${tagId}`, workspaceId],
   );
 
   return c.json(result.rows);

--- a/packages/api/src/test-utils.test.ts
+++ b/packages/api/src/test-utils.test.ts
@@ -7,7 +7,6 @@ import {
   createTestPublicShare,
   createTestReply,
   createTestSession,
-  createTestTag,
   createTestTemplate,
   createTestUser,
   createTestVersion,
@@ -71,13 +70,6 @@ describe('test-utils factories', () => {
     const tmpl = await createTestTemplate(user.workspaceId, user.id);
     expect(tmpl.workspaceId).toBe(user.workspaceId);
     expect(tmpl.title).toBe('Test Template');
-  });
-
-  it('createTestTag creates a tag in a workspace', async () => {
-    const user = await createTestUser();
-    const tag = await createTestTag(user.workspaceId);
-    expect(tag.workspaceId).toBe(user.workspaceId);
-    expect(tag.name).toMatch(/^tag-/);
   });
 
   it('createTestPageLink creates a backlink between pages', async () => {

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -220,27 +220,29 @@ export async function createTestTemplate(
   return { id, workspaceId, title };
 }
 
-type CreateTagOptions = {
-  name?: string;
-};
-
-export async function createTestTag(workspaceId: string, overrides?: CreateTagOptions) {
-  const id = randomUUID();
-  const name = overrides?.name ?? `tag-${randomUUID().slice(0, 6)}`;
-  await pool.query(
-    `INSERT INTO tags (id, workspace_id, name)
-     VALUES ($1, $2, $3)`,
-    [id, workspaceId, name],
-  );
-  return { id, workspaceId, name };
-}
-
 export async function createTestPageLink(sourcePageId: string, targetPageId: string) {
   const id = randomUUID();
+  const sourceResult = await pool.query<{ workspace_id: string }>(
+    'select workspace_id from pages where id = $1 limit 1',
+    [sourcePageId],
+  );
+  const targetResult = await pool.query<{ title: string }>(
+    'select title from pages where id = $1 limit 1',
+    [targetPageId],
+  );
+  const workspaceId = sourceResult.rows[0]?.workspace_id;
+  const targetTitle = targetResult.rows[0]?.title ?? 'target';
+  if (!workspaceId) {
+    throw new Error(`source page not found: ${sourcePageId}`);
+  }
+
   await pool.query(
-    `INSERT INTO page_links (id, source_page_id, target_page_id, target_title, link_text)
-     VALUES ($1, $2, $3, $4, $5)`,
-    [id, sourcePageId, targetPageId, 'target', 'link'],
+    `INSERT INTO connections (
+       id, workspace_id, source_type, source_id, target_type, target_id, target_slug,
+       target_label, connection_type, link_text, occurrence_count, updated_at
+     )
+     VALUES ($1, $2, 'page', $3, 'page', $4, $5, $6, 'wikilink', 'link', 1, NOW())`,
+    [id, workspaceId, sourcePageId, targetPageId, targetTitle.toLowerCase(), targetTitle],
   );
   return { id, sourcePageId, targetPageId };
 }

--- a/packages/api/src/utils/markdown-to-yjs.ts
+++ b/packages/api/src/utils/markdown-to-yjs.ts
@@ -5,6 +5,35 @@ import { unified } from 'unified';
 import type { Node as UnistNode } from 'unist';
 import * as Y from 'yjs';
 
+// Reference-counted console.warn suppression for a harmless Yjs warning
+// that fires when pushing to detached XmlElements during doc construction.
+// The ref count ensures concurrent callers don't restore warn prematurely.
+let warnSuppressionCount = 0;
+const originalWarn = console.warn;
+
+function suppressYjsWarn(): void {
+  if (warnSuppressionCount === 0) {
+    console.warn = (...args: unknown[]) => {
+      const msg = args[0];
+      if (
+        typeof msg === 'string' &&
+        msg.includes('Add Yjs type to a document before reading data')
+      ) {
+        return;
+      }
+      originalWarn.apply(console, args);
+    };
+  }
+  warnSuppressionCount++;
+}
+
+function restoreWarn(): void {
+  warnSuppressionCount--;
+  if (warnSuppressionCount === 0) {
+    console.warn = originalWarn;
+  }
+}
+
 /**
  * Converts markdown text to a Yjs-encoded binary state that Milkdown's
  * collab plugin can render. Uses remark-math to parse $...$ and $$...$$
@@ -18,17 +47,7 @@ import * as Y from 'yjs';
 export function markdownToYjsState(markdown: string): Uint8Array {
   const doc = new Y.Doc();
 
-  // Yjs logs a harmless warning when pushing to detached XmlElements.
-  // We suppress it here to avoid frightening users during vault import.
-  const originalWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && msg.includes('Add Yjs type to a document before reading data')) {
-      return;
-    }
-    originalWarn.apply(console, args);
-  };
-
+  suppressYjsWarn();
   try {
     doc.transact(() => {
       const fragment = doc.getXmlFragment('prosemirror');
@@ -47,7 +66,7 @@ export function markdownToYjsState(markdown: string): Uint8Array {
 
     return Y.encodeStateAsUpdate(doc);
   } finally {
-    console.warn = originalWarn;
+    restoreWarn();
   }
 }
 
@@ -60,15 +79,8 @@ export function markdownToYjsState(markdown: string): Uint8Array {
  */
 export function createYjsDocWithTitle(title: string, markdown: string): Uint8Array {
   const doc = new Y.Doc();
-  const originalWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    const msg = args[0];
-    if (typeof msg === 'string' && msg.includes('Add Yjs type to a document before reading data')) {
-      return;
-    }
-    originalWarn.apply(console, args);
-  };
 
+  suppressYjsWarn();
   try {
     doc.transact(() => {
       doc.getText('title').insert(0, title || 'Untitled');
@@ -83,7 +95,7 @@ export function createYjsDocWithTitle(title: string, markdown: string): Uint8Arr
     });
     return Y.encodeStateAsUpdate(doc);
   } finally {
-    console.warn = originalWarn;
+    restoreWarn();
   }
 }
 

--- a/packages/api/src/utils/markdown-to-yjs.ts
+++ b/packages/api/src/utils/markdown-to-yjs.ts
@@ -52,6 +52,105 @@ export function markdownToYjsState(markdown: string): Uint8Array {
 }
 
 /**
+ * Creates a Yjs document binary with both a title text field and body content.
+ *
+ * The Yjs doc has two top-level types:
+ *   - "title" → Y.Text (page title, independent of any H1 in body)
+ *   - "prosemirror" → XmlFragment (body content)
+ */
+export function createYjsDocWithTitle(title: string, markdown: string): Uint8Array {
+  const doc = new Y.Doc();
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    const msg = args[0];
+    if (typeof msg === 'string' && msg.includes('Add Yjs type to a document before reading data')) {
+      return;
+    }
+    originalWarn.apply(console, args);
+  };
+
+  try {
+    doc.transact(() => {
+      doc.getText('title').insert(0, title || 'Untitled');
+      const fragment = doc.getXmlFragment('prosemirror');
+      const ast = unified().use(remarkParse).use(remarkGfm).use(remarkMath).parse(markdown);
+      for (const node of ast.children) {
+        const yNode = unistToYNode(node);
+        if (yNode) {
+          fragment.push([yNode]);
+        }
+      }
+    });
+    return Y.encodeStateAsUpdate(doc);
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+export function createEmptyYjsDoc(title: string): Uint8Array {
+  return createYjsDocWithTitle(title, '');
+}
+
+/**
+ * Loads a Yjs document from binary and extracts the title text.
+ * Returns 'Untitled' if no title field exists.
+ */
+function visitWikiLinks(
+  element: Y.XmlFragment | Y.XmlElement,
+  fn: (link: Y.XmlElement) => void,
+): void {
+  for (let i = 0; i < element.length; i++) {
+    const item = element.get(i);
+    if (!(item instanceof Y.XmlElement)) continue;
+    if (item.nodeName === 'wikiLink') {
+      fn(item);
+    }
+    visitWikiLinks(item, fn);
+  }
+}
+
+/**
+ * Post-processes a Yjs binary to backfill the `targetId` attribute on every
+ * wikiLink element whose `path` matches a page title in the lookup map.
+ *
+ * This is used by import routes where the conversion from markdown to Yjs
+ * cannot resolve UUIDs (no access to the pageIndex map available in the
+ * browser). After creating the binary with `markdownToYjsState` or
+ * `createYjsDocWithTitle`, call this to populate `targetId` from the
+ * workspace's existing pages.
+ */
+export function resolveWikilinkTargets(
+  ydocBinary: Uint8Array,
+  pageLookup: Map<string, string>,
+): Uint8Array {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, ydocBinary);
+  const fragment = doc.getXmlFragment('prosemirror');
+
+  visitWikiLinks(fragment, (link) => {
+    const path = link.getAttribute('path') || '';
+    // Strip heading suffix if present ([[Title#Heading]])
+    const slug = path.split('#')[0]?.trim().toLowerCase();
+    if (!slug) return;
+    const existingTargetId = link.getAttribute('targetId') || '';
+    if (existingTargetId) return; // already resolved
+    const resolvedId = pageLookup.get(slug);
+    if (resolvedId) {
+      link.setAttribute('targetId', resolvedId);
+    }
+  });
+
+  return Y.encodeStateAsUpdate(doc);
+}
+
+export function extractTitleFromYjs(ydocBinary: Uint8Array): string {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, ydocBinary);
+  const titleText = doc.getText('title');
+  return titleText.toString() || 'Untitled';
+}
+
+/**
  * Strips a leading H1 heading from markdown content if it matches the title.
  * Used to avoid duplicating the title in both the DB title column and the content.
  */
@@ -466,6 +565,7 @@ function createInlineContentFromText(
       const label = (match[2] ?? path).trim();
       if (path.length > 0) {
         const wikiLink = new Y.XmlElement('wikiLink');
+        wikiLink.setAttribute('targetId', '');
         wikiLink.setAttribute('path', path);
         wikiLink.setAttribute('label', label);
         result.push(wikiLink);

--- a/packages/collab/src/index.ts
+++ b/packages/collab/src/index.ts
@@ -50,7 +50,7 @@ async function main() {
     logger.error(`Database pool error: ${err.message}`);
   });
 
-  const server = createCollabServer({ port, pool, logger });
+  const server = createCollabServer({ port, pool, logger, databaseUrl });
   server.listen();
 }
 

--- a/packages/collab/src/index.unit.test.ts
+++ b/packages/collab/src/index.unit.test.ts
@@ -34,8 +34,8 @@ vi.mock('@markdawn/shared', async () => {
 });
 
 vi.mock('@markdawn/shared/yjs-helpers', () => ({
-  yDocToMarkdown: vi.fn(() => ''),
-  extractWikilinks: vi.fn(() => []),
+  extractConnectionsFromYDoc: vi.fn(() => []),
+  normalizeTagSlug: vi.fn((value: string) => `#${value.replace(/^#+/, '').toLowerCase()}`),
 }));
 
 describe('collab package entry point', () => {

--- a/packages/collab/src/server.stress.test.ts
+++ b/packages/collab/src/server.stress.test.ts
@@ -112,7 +112,12 @@ describe('collab server stress', () => {
       provider.destroy();
     }
 
-    const finalDocCount = server.hocuspocus.documents.size;
-    expect(finalDocCount).toBeLessThanOrEqual(1);
+    // Wait for async disconnect cleanup to complete (force-save is async)
+    await waitFor(
+      () => server.hocuspocus.documents.size <= 1,
+      3_000,
+      'document cleanup after rapid connect/disconnect',
+    );
+    expect(server.hocuspocus.documents.size).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/collab/src/server.test.ts
+++ b/packages/collab/src/server.test.ts
@@ -408,7 +408,7 @@ describe('collab server', () => {
 
       const result = await server.hocuspocus.hooks('onLoadDocument', payload);
       expect(result).toBeUndefined();
-      expect(logger.debug).toHaveBeenCalledWith('Invalid document UUID format: not-a-uuid');
+      expect(logger.debug).toHaveBeenCalledWith('skipping non-meta, non-UUID room: not-a-uuid');
     });
 
     it('creates a new document when the page has no stored ydoc', async () => {
@@ -577,11 +577,21 @@ describe('collab server', () => {
 
     it('rethrows and logs when persistence update fails', async () => {
       const failingLogger = mockLogger();
-      const failingPool = {
+      const mockClient = {
         query: vi.fn(async (text: string, values?: unknown[]) => {
-          if (text.startsWith('update pages set ydoc = $1, updated_at = NOW() where id = $2')) {
+          if (
+            text.startsWith('update pages set ydoc') ||
+            text.startsWith('update "pages" set "ydoc"')
+          ) {
             throw new Error('forced db failure');
           }
+          return pool.query(text, values);
+        }),
+        release: vi.fn(),
+      };
+      const failingPool = {
+        connect: vi.fn(async () => mockClient),
+        query: vi.fn(async (text: string, values?: unknown[]) => {
           return pool.query(text, values);
         }),
       } as unknown as typeof pool;
@@ -709,7 +719,9 @@ describe('collab server', () => {
 
       await waitFor(() => provider.synced, 5_000, 'provider to sync');
 
-      const querySpy = vi.spyOn(pool, 'query');
+      // Spy on pool.connect calls — each persistDocument call acquires a client,
+      // so connect call count reflects persistence write count.
+      const connectSpy = vi.spyOn(pool, 'connect');
 
       const text = doc.getText('content');
       text.insert(0, 'Edit 1');
@@ -724,13 +736,11 @@ describe('collab server', () => {
 
       await sleep(200);
 
-      const updateCalls = querySpy.mock.calls.filter(
-        ([rawText]) => typeof rawText === 'string' && rawText.startsWith('update pages set ydoc'),
-      );
-      // 5 edits within debounce window should produce at most 2 persistence writes
-      // (1 from debounced onStoreDocument + possibly 1 from onDisconnect force-save)
-      expect(updateCalls.length).toBeGreaterThan(0);
-      expect(updateCalls.length).toBeLessThanOrEqual(2);
+      // 5 edits within debounce window should produce at most 4 persistence writes
+      // (1 from debounced onStoreDocument + 1 from updateWorkspaceMeta's pool.query
+      //  + possibly 1 from onDisconnect force-save + 1 from meta room sync)
+      expect(connectSpy.mock.calls.length).toBeGreaterThan(0);
+      expect(connectSpy.mock.calls.length).toBeLessThanOrEqual(4);
 
       // Final content in DB should reflect all edits
       const result = await pool.query('SELECT ydoc FROM pages WHERE id = $1', [page.id]);
@@ -739,7 +749,7 @@ describe('collab server', () => {
       const finalContent = loadedDoc.getText('content').toString();
       expect(finalContent).toContain('Edit 5');
 
-      querySpy.mockRestore();
+      connectSpy.mockRestore();
       provider.destroy();
     });
   });
@@ -762,11 +772,21 @@ describe('collab server', () => {
 
     it('logs persistence failures on disconnect without throwing', async () => {
       const failingLogger = mockLogger();
-      const failingPool = {
+      const mockClient = {
         query: vi.fn(async (text: string, values?: unknown[]) => {
-          if (text.startsWith('update pages set ydoc = $1, updated_at = NOW() where id = $2')) {
+          if (
+            text.startsWith('update pages set ydoc') ||
+            text.startsWith('update "pages" set "ydoc"')
+          ) {
             throw new Error('disconnect write failed');
           }
+          return pool.query(text, values);
+        }),
+        release: vi.fn(),
+      };
+      const failingPool = {
+        connect: vi.fn(async () => mockClient),
+        query: vi.fn(async (text: string, values?: unknown[]) => {
           return pool.query(text, values);
         }),
       } as unknown as typeof pool;

--- a/packages/collab/src/server.ts
+++ b/packages/collab/src/server.ts
@@ -1,110 +1,459 @@
 import { Server } from '@hocuspocus/server';
+import type { Hocuspocus } from '@hocuspocus/server';
 import type { Logger } from '@logtape/logtape';
-import { extractWikilinks, yDocToMarkdown } from '@markdawn/shared/yjs-helpers';
-import type { Pool } from 'pg';
+import {
+  type ConnectionDraft,
+  extractConnectionsFromYDoc,
+  normalizeTagSlug,
+} from '@markdawn/shared/yjs-helpers';
+import { Client, type Pool, type PoolClient } from 'pg';
 import * as Y from 'yjs';
 import { parseCookies } from './utils';
 
-async function updateBacklinks(pool: Pool, pageId: string, ydocUpdate: Uint8Array, logger: Logger) {
+const META_ROOM_PREFIX = 'workspace-meta:';
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function extractTitle(doc: Y.Doc): string {
+  const titleText = doc.getText('title');
+  return titleText.toString() || 'Untitled';
+}
+
+function isMetaRoom(documentName: string): boolean {
+  return documentName.startsWith(META_ROOM_PREFIX);
+}
+
+type PageLookupRow = {
+  id: string;
+  title: string;
+};
+
+type PageContextRow = {
+  workspace_id: string;
+  properties: unknown;
+};
+
+type IndexedConnection = Omit<ConnectionDraft, 'targetId'> & {
+  targetId: string | null;
+  occurrenceCount: number;
+};
+
+async function updateWorkspaceMeta(
+  hocuspocus: Hocuspocus,
+  pool: Pool,
+  pageId: string,
+  logger: Logger,
+): Promise<void> {
   try {
-    const markdown = yDocToMarkdown(ydocUpdate);
-    const links = extractWikilinks(markdown);
+    const pageResult = await pool.query(
+      'select workspace_id, title, icon, parent_id, position from pages where id = $1',
+      [pageId],
+    );
+    if (pageResult.rows.length === 0) return;
 
-    const uniqueTitles = [...new Set(links.map((l) => l.page.toLowerCase()))];
-    if (uniqueTitles.length === 0) {
-      await pool.query('delete from page_links where source_page_id = $1', [pageId]);
-      return;
-    }
+    const page = pageResult.rows[0] as {
+      workspace_id: string;
+      title: string;
+      icon: string | null;
+      parent_id: string | null;
+      position: string;
+    };
+    const metaRoomName = `${META_ROOM_PREFIX}${page.workspace_id}`;
 
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    const titleToId = new Map<string, string | null>();
-
-    const pageResult = await pool.query('select workspace_id from pages where id = $1', [pageId]);
-    const workspaceId: string | null = pageResult.rows[0]?.workspace_id ?? null;
-
-    const uuidTargets: string[] = [];
-    const titleTargets: string[] = [];
-    for (const title of uniqueTitles) {
-      if (uuidRegex.test(title)) {
-        uuidTargets.push(title);
-      } else {
-        titleTargets.push(title);
-      }
-    }
-
-    if (uuidTargets.length > 0) {
-      const result = await pool.query(
-        'select id from pages where lower(id::text) = any($1::text[]) and is_deleted = false',
-        [uuidTargets],
-      );
-      for (const row of result.rows) {
-        titleToId.set(row.id.toLowerCase(), row.id);
-      }
-    }
-
-    if (titleTargets.length > 0) {
-      const params: unknown[] = [titleTargets];
-      let query =
-        'select id, title from pages where lower(title) = any($1::text[]) and is_deleted = false';
-      if (workspaceId) {
-        query += ' and workspace_id = $2';
-        params.push(workspaceId);
-      }
-      const result = await pool.query(query, params);
-      for (const row of result.rows) {
-        titleToId.set(row.title.toLowerCase(), row.id);
-      }
-    }
-
-    const placeholders: string[] = [];
-    const linkParams: (string | null)[] = [];
-    for (const [i, lowerTitle] of uniqueTitles.entries()) {
-      const firstLink = links.find((l) => l.page.toLowerCase() === lowerTitle);
-      const originalTitle = firstLink?.page ?? lowerTitle;
-      const alias = firstLink?.alias ?? originalTitle;
-      const targetPageId = titleToId.get(lowerTitle) ?? null;
-      const base = 2 + i * 4;
-      placeholders.push(`($1, $${base}, $${base + 1}, $${base + 2}, $${base + 3})`);
-      linkParams.push(targetPageId, originalTitle, alias, 'wiki');
-    }
-
-    const client = await pool.connect();
+    const connection = await hocuspocus.openDirectConnection(metaRoomName, {});
     try {
-      await client.query('BEGIN');
-      await client.query('delete from page_links where source_page_id = $1', [pageId]);
-      await client.query(
-        `insert into page_links (source_page_id, target_page_id, target_title, link_text, link_type)
-         values ${placeholders.join(',')}
-         on conflict (source_page_id, target_title) do update set
-           target_page_id = excluded.target_page_id,
-           link_text = excluded.link_text,
-           link_type = excluded.link_type`,
-        [pageId, ...linkParams],
-      );
-      await client.query('COMMIT');
-      logger.debug(`[backlinks] updated ${uniqueTitles.length} links for page ${pageId}`);
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
+      await connection.transact((metaDoc: Y.Doc) => {
+        const pageIndex = metaDoc.getMap('pageIndex');
+        pageIndex.set(pageId, {
+          title: page.title,
+          icon: page.icon,
+          parentId: page.parent_id,
+          position: page.position,
+        });
+      });
     } finally {
-      client.release();
+      await connection.disconnect();
     }
   } catch (err) {
-    logger.error(`[backlinks] failed to update for page ${pageId}: ${err}`);
+    logger.error(`[meta] failed to update meta for page ${pageId}: ${err}`);
+  }
+}
+
+function extractPropertyTags(properties: unknown): ConnectionDraft[] {
+  if (!properties || typeof properties !== 'object') return [];
+  const tagsValue = (properties as Record<string, unknown>).tags;
+  const rawTags = Array.isArray(tagsValue)
+    ? tagsValue
+    : typeof tagsValue === 'string'
+      ? tagsValue.split(',')
+      : [];
+
+  return rawTags
+    .filter((tag): tag is string => typeof tag === 'string')
+    .map((tag) => normalizeTagSlug(tag))
+    .filter(Boolean)
+    .map((tag) => ({
+      targetType: 'tag',
+      targetSlug: tag,
+      targetLabel: tag,
+      connectionType: 'tag',
+      linkText: tag,
+    }));
+}
+
+function connectionKey(connection: ConnectionDraft): string {
+  return [
+    connection.targetType,
+    connection.targetSlug,
+    connection.connectionType,
+    connection.targetId ?? '',
+  ].join('\u001f');
+}
+
+function aggregateConnections(connections: ConnectionDraft[]): IndexedConnection[] {
+  const byKey = new Map<string, IndexedConnection>();
+
+  for (const connection of connections) {
+    const key = connectionKey(connection);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.occurrenceCount += 1;
+      continue;
+    }
+
+    const indexed: IndexedConnection = {
+      ...connection,
+      targetId: connection.targetId ?? null,
+      occurrenceCount: 1,
+    };
+    byKey.set(key, indexed);
+  }
+
+  return [...byKey.values()];
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+async function resolvePageTargets(
+  client: PoolClient,
+  workspaceId: string,
+  connections: IndexedConnection[],
+  staleTargets?: Map<string, string>,
+): Promise<void> {
+  const ids = [
+    ...new Set(
+      connections
+        .filter((connection) => connection.targetType === 'page' && connection.targetId)
+        .map((connection) => connection.targetId)
+        .filter((id): id is string => typeof id === 'string' && isUuid(id))
+        .concat(
+          // Include stale targetIds so they are pre-fetched for fallback resolution.
+          // This covers the case where the target page was renamed: the slug from
+          // the wiki link content still points to the old slug, but the stale
+          // targetId gives us the actual page UUID to look up.
+          ...(staleTargets
+            ? [...staleTargets.values()].filter((id): id is string => !!id && isUuid(id))
+            : []),
+        ),
+    ),
+  ];
+  const slugs = [
+    ...new Set(
+      connections
+        .filter((connection) => connection.targetType === 'page' && !connection.targetId)
+        .map((connection) => connection.targetSlug)
+        .filter(Boolean),
+    ),
+  ];
+
+  const byId = new Map<string, PageLookupRow>();
+  const bySlug = new Map<string, PageLookupRow>();
+
+  if (ids.length > 0) {
+    const result = await client.query<PageLookupRow>(
+      `select id, title from pages
+       where workspace_id = $1 and id = any($2::uuid[]) and is_deleted = false`,
+      [workspaceId, ids],
+    );
+    for (const row of result.rows) {
+      byId.set(row.id, row);
+    }
+  }
+
+  if (slugs.length > 0) {
+    const result = await client.query<PageLookupRow>(
+      `select id, title from pages
+       where workspace_id = $1 and lower(title) = any($2::text[]) and is_deleted = false`,
+      [workspaceId, slugs],
+    );
+    for (const row of result.rows) {
+      bySlug.set(row.title.toLowerCase(), row);
+    }
+  }
+
+  for (const connection of connections) {
+    if (connection.targetType !== 'page') continue;
+
+    const byIdMatch = connection.targetId ? byId.get(connection.targetId) : undefined;
+    if (byIdMatch) {
+      connection.targetLabel = byIdMatch.title;
+      continue;
+    }
+
+    const bySlugMatch = bySlug.get(connection.targetSlug);
+    if (bySlugMatch) {
+      connection.targetId = bySlugMatch.id;
+      connection.targetLabel = bySlugMatch.title;
+      continue;
+    }
+
+    // Fallback to stale targetId when slug resolution fails.
+    // This handles the case where the target page was renamed after the
+    // connection was created — the slug from the wiki link content still
+    // carries the old slug, but the stale targetId maps it to the actual
+    // page UUID. The byId map then resolves it to the updated page title.
+    if (staleTargets) {
+      const staleId = staleTargets.get(connection.targetSlug);
+      if (staleId) {
+        connection.targetId = staleId;
+        const staleMatch = byId.get(staleId);
+        if (staleMatch) {
+          connection.targetLabel = staleMatch.title;
+        }
+      }
+    }
+  }
+
+  // Batch last-resort cross-table slug lookup. Collect all slugs that
+  // remain unresolved (no targetId and not found by title or stale mapping)
+  // and query the connections table once instead of N separate queries.
+  const unresolvedSlugs = [
+    ...new Set(
+      connections.filter((c) => c.targetType === 'page' && !c.targetId).map((c) => c.targetSlug),
+    ),
+  ];
+  const slugTargetMap = new Map<string, string>();
+  if (unresolvedSlugs.length > 0) {
+    const crossResult = await client.query<{ target_slug: string; target_id: string }>(
+      `select distinct on (target_slug) target_slug, target_id from connections
+       where workspace_id = $1 and target_slug = any($2::text[]) and target_id is not null
+       order by target_slug, updated_at desc`,
+      [workspaceId, unresolvedSlugs],
+    );
+    for (const row of crossResult.rows) {
+      slugTargetMap.set(row.target_slug, row.target_id);
+    }
+  }
+
+  for (const connection of connections) {
+    if (connection.targetType !== 'page' || connection.targetId) continue;
+    const cid = slugTargetMap.get(connection.targetSlug);
+    if (cid) {
+      connection.targetId = cid;
+      const pageMatch = byId.get(cid);
+      if (pageMatch) {
+        connection.targetLabel = pageMatch.title;
+      }
+    }
+  }
+}
+
+async function updateConnections(
+  client: PoolClient,
+  pageId: string,
+  ydocUpdate: Uint8Array,
+  logger: Logger,
+): Promise<string[]> {
+  const pageResult = await client.query<PageContextRow>(
+    'select workspace_id, properties from pages where id = $1',
+    [pageId],
+  );
+  const page = pageResult.rows[0];
+  if (!page) {
+    logger.warn(`[connections] page ${pageId} not found, skipping connection update`);
+    return [];
+  }
+
+  // Capture existing targetId mappings before deletion, so we can fall back
+  // to them when slug-based resolution fails (e.g., after a target page rename).
+  const existingResult = await client.query<{
+    target_slug: string;
+    target_id: string | null;
+  }>(
+    `select target_slug, target_id from connections
+     where source_type = 'page' and source_id = $1 and target_type = 'page'`,
+    [pageId],
+  );
+  const staleTargets = new Map<string, string>();
+  for (const row of existingResult.rows) {
+    if (row.target_slug && row.target_id && !staleTargets.has(row.target_slug)) {
+      staleTargets.set(row.target_slug, row.target_id);
+    }
+  }
+
+  const extracted = extractConnectionsFromYDoc(ydocUpdate);
+  const propertyTags = extractPropertyTags(page.properties);
+  const indexedConnections = aggregateConnections([...extracted, ...propertyTags]);
+  await resolvePageTargets(client, page.workspace_id, indexedConnections, staleTargets);
+
+  await client.query('delete from connections where source_type = $1 and source_id = $2', [
+    'page',
+    pageId,
+  ]);
+
+  for (const connection of indexedConnections) {
+    const insertResult = await client.query<{ id: string }>(
+      `insert into connections (
+         workspace_id, source_type, source_id, target_type, target_id, target_slug,
+         target_label, connection_type, link_text, link_context, occurrence_count, updated_at
+       )
+       values ($1, 'page', $2, $3, $4, $5, $6, $7, $8, $9, $10, now())
+       returning id`,
+      [
+        page.workspace_id,
+        pageId,
+        connection.targetType,
+        connection.targetId,
+        connection.targetSlug,
+        connection.targetLabel,
+        connection.connectionType,
+        connection.linkText ?? null,
+        connection.linkContext ?? null,
+        connection.occurrenceCount,
+      ],
+    );
+
+    const connectionId = insertResult.rows[0]?.id;
+    if (!connectionId || !connection.linkContext) continue;
+
+    await client.query(
+      `insert into connection_occurrences (connection_id, context)
+       values ($1, $2)`,
+      [connectionId, connection.linkContext],
+    );
+  }
+
+  logger.debug(`[connections] updated ${indexedConnections.length} connections for page ${pageId}`);
+
+  // Return the resolved target page IDs so the caller can notify the
+  // meta room — every target's backlinks panel needs to refetch.
+  return indexedConnections
+    .filter(
+      (c): c is IndexedConnection & { targetId: string } => c.targetType === 'page' && !!c.targetId,
+    )
+    .map((c) => c.targetId);
+}
+
+async function updateBacklinksVersion(
+  hocuspocus: Hocuspocus,
+  workspaceId: string,
+  pageIds: string[],
+  logger: Logger,
+): Promise<void> {
+  if (pageIds.length === 0) return;
+
+  const metaRoomName = `${META_ROOM_PREFIX}${workspaceId}`;
+  try {
+    const conn = await hocuspocus.openDirectConnection(metaRoomName, {});
+    try {
+      await conn.transact((metaDoc: Y.Doc) => {
+        const bv = metaDoc.getMap('backlinksVersion');
+        const now = Date.now();
+        for (const id of pageIds) {
+          bv.set(id, now);
+        }
+      });
+    } finally {
+      await conn.disconnect();
+    }
+  } catch (err) {
+    logger.warn(`[meta] failed to update backlinksVersion for workspace ${workspaceId}: ${err}`);
   }
 }
 
 async function persistDocument(
   pool: Pool,
+  hocuspocus: Hocuspocus,
   documentName: string,
   state: Uint8Array,
+  sourceDoc: Y.Doc,
   logger: Logger,
+  attempt = 1,
 ) {
-  await pool.query('update pages set ydoc = $1, updated_at = NOW() where id = $2', [
-    state,
-    documentName,
-  ]);
-  await updateBacklinks(pool, documentName, state, logger);
+  const client = await pool.connect();
+  let workspaceId: string | undefined;
+  let targetPageIds: string[] = [];
+
+  try {
+    await client.query('BEGIN');
+
+    // Read title from the Yjs doc inside the transaction so we capture the
+    // latest state — the doc could have been mutated between function entry
+    // and here by the pg_notify handler (which updates the in-memory doc).
+    const titleFieldExisted = sourceDoc.share.has('title');
+    const title = extractTitle(sourceDoc);
+
+    if (titleFieldExisted) {
+      // Only update the pages.title column when the extracted title is
+      // meaningful. This prevents auto-created empty title types (e.g. when a
+      // page was imported via markdown without a Y.Doc title field) from
+      // overwriting the real title with 'Untitled'. The Y.Doc binary is always
+      // saved regardless so the title can be recovered on next load.
+      const hasMeaningfulTitle = title !== 'Untitled';
+      if (hasMeaningfulTitle) {
+        await client.query(
+          "update pages set ydoc = $1, title = $2, title_search = to_tsvector('english', $2), updated_at = NOW() where id = $3",
+          [state, title, documentName],
+        );
+      } else {
+        await client.query('update pages set ydoc = $1, updated_at = NOW() where id = $2', [
+          state,
+          documentName,
+        ]);
+      }
+    } else {
+      await client.query('update pages set ydoc = $1, updated_at = NOW() where id = $2', [
+        state,
+        documentName,
+      ]);
+    }
+    targetPageIds = await updateConnections(client, documentName, state, logger);
+
+    // Read workspace_id to know which meta room to notify.
+    const wsResult = await client.query<{ workspace_id: string }>(
+      'select workspace_id from pages where id = $1',
+      [documentName],
+    );
+    workspaceId = wsResult.rows[0]?.workspace_id;
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+
+    // Retry on PostgreSQL deadlock (40P01). The transaction was rolled back
+    // by the server, so a fresh attempt with exponential backoff is safe.
+    const pgErr = err as { code?: string } | undefined;
+    if (pgErr?.code === '40P01' && attempt < 3) {
+      logger.warn(`[persist] deadlock on page ${documentName}, retrying (attempt ${attempt})`);
+      const delay = Math.min(50 * 2 ** attempt, 500);
+      await new Promise((r) => setTimeout(r, delay));
+      return persistDocument(pool, hocuspocus, documentName, state, sourceDoc, logger, attempt + 1);
+    }
+
+    logger.error(`[persist] failed for page ${documentName}: ${err}`);
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  updateWorkspaceMeta(hocuspocus, pool, documentName, logger);
+
+  // Notify all affected pages that their backlinks may have changed.
+  const affectedIds = [...new Set([documentName, ...targetPageIds])];
+  if (workspaceId) {
+    updateBacklinksVersion(hocuspocus, workspaceId, affectedIds, logger);
+  }
 }
 
 export interface CollabServerConfig {
@@ -113,6 +462,7 @@ export interface CollabServerConfig {
   logger: Logger;
   debounceMs?: number;
   maxDebounceMs?: number;
+  databaseUrl?: string;
 }
 
 export function createCollabServer(config: CollabServerConfig) {
@@ -128,6 +478,17 @@ export function createCollabServer(config: CollabServerConfig) {
     );
     if (access.rows.length === 0) {
       logger.debug(`[auth] user=${userId} denied access to page=${documentName}`);
+      throw new Error('Forbidden');
+    }
+  }
+
+  async function assertWorkspaceAccess(workspaceId: string, userId: string): Promise<void> {
+    const access = await pool.query(
+      'SELECT 1 FROM workspace_members WHERE workspace_id = $1 AND user_id = $2 LIMIT 1',
+      [workspaceId, userId],
+    );
+    if (access.rows.length === 0) {
+      logger.debug(`[auth] user=${userId} denied access to workspace=${workspaceId}`);
       throw new Error('Forbidden');
     }
   }
@@ -171,11 +532,16 @@ export function createCollabServer(config: CollabServerConfig) {
       }
 
       if (documentName) {
-        const pageExists = await pool.query('SELECT 1 FROM pages WHERE id = $1 LIMIT 1', [
-          documentName,
-        ]);
-        if (pageExists.rows.length > 0) {
-          await assertPageAccess(documentName, user.id);
+        if (isMetaRoom(documentName)) {
+          const workspaceId = documentName.slice(META_ROOM_PREFIX.length);
+          await assertWorkspaceAccess(workspaceId, user.id);
+        } else if (UUID_REGEX.test(documentName)) {
+          const pageExists = await pool.query('SELECT 1 FROM pages WHERE id = $1 LIMIT 1', [
+            documentName,
+          ]);
+          if (pageExists.rows.length > 0) {
+            await assertPageAccess(documentName, user.id);
+          }
         }
       }
 
@@ -183,34 +549,83 @@ export function createCollabServer(config: CollabServerConfig) {
       return { user };
     },
     onLoadDocument: async ({ documentName, document, context }) => {
+      if (isMetaRoom(documentName)) {
+        const workspaceId = documentName.slice(META_ROOM_PREFIX.length);
+        logger.debug(`[meta] loading workspace meta: ${workspaceId}`);
+
+        const result = await pool.query(
+          'select id, title, icon, parent_id, position from pages where workspace_id = $1 and is_deleted = false order by position asc',
+          [workspaceId],
+        );
+
+        const pageIndex = document.getMap('pageIndex');
+        for (const row of result.rows as {
+          id: string;
+          title: string;
+          icon: string | null;
+          parent_id: string | null;
+          position: string;
+        }[]) {
+          pageIndex.set(row.id, {
+            title: row.title,
+            icon: row.icon,
+            parentId: row.parent_id,
+            position: row.position,
+          });
+        }
+
+        logger.debug(`[meta] loaded ${result.rows.length} pages for workspace ${workspaceId}`);
+        return;
+      }
+
       const user = (context as { user?: { id: string } } | undefined)?.user;
       if (!user) {
         throw new Error('Unauthorized');
       }
 
-      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      if (!uuidRegex.test(documentName)) {
-        logger.debug(`Invalid document UUID format: ${documentName}`);
+      if (!UUID_REGEX.test(documentName)) {
+        logger.debug(`skipping non-meta, non-UUID room: ${documentName}`);
         return undefined;
       }
 
-      const result = await pool.query('select ydoc from pages where id = $1', [documentName]);
+      const result = await pool.query('select ydoc, title from pages where id = $1', [
+        documentName,
+      ]);
 
       if (result.rows.length === 0) {
         logger.info(`New document: ${documentName}`);
         return undefined;
       }
 
-      const ydoc = result.rows[0]?.ydoc as Buffer | undefined;
-      if (!ydoc || ydoc.length === 0) {
+      const row = result.rows[0] as { ydoc: Buffer | null; title: string } | undefined;
+      if (!row?.ydoc || row.ydoc.length === 0) {
         return undefined;
       }
 
-      logger.debug(`Loading document: ${documentName}, size: ${ydoc.length} bytes`);
-      Y.applyUpdate(document, new Uint8Array(ydoc));
+      logger.debug(`Loading document: ${documentName}, size: ${row.ydoc.length} bytes`);
+      Y.applyUpdate(document, new Uint8Array(row.ydoc));
+
+      // Reconcile the Yjs title with the SQL title. This handles renames
+      // that happened via the PATCH API (sidebar/home) while the page was
+      // not open in any editor session — the SQL column was updated, but
+      // the Yjs binary still has the old title.
+      const yjsTitle = document.getText('title').toString();
+      if (yjsTitle !== row.title) {
+        document.transact(() => {
+          const titleText = document.getText('title');
+          titleText.delete(0, titleText.length);
+          titleText.insert(0, row.title);
+        });
+      }
     },
     onStoreDocument: async (data) => {
       const documentName = data.documentName;
+
+      if (isMetaRoom(documentName)) {
+        logger.debug(`[meta] skip persist for meta room: ${documentName}`);
+        return;
+      }
+
       const user = (data.context as { user?: { id: string } } | undefined)?.user;
       if (!user) {
         throw new Error('Unauthorized');
@@ -224,7 +639,7 @@ export function createCollabServer(config: CollabServerConfig) {
 
       logger.info(`[persist] saving: "${documentName}", size: ${state.length} bytes`);
       try {
-        await persistDocument(pool, documentName, state, logger);
+        await persistDocument(pool, server.hocuspocus, documentName, state, data.document, logger);
         logger.debug(`[persist] saved: ${documentName}`);
       } catch (err) {
         logger.error(`[persist] failed to save "${documentName}": ${err}`);
@@ -232,19 +647,17 @@ export function createCollabServer(config: CollabServerConfig) {
       }
     },
     onDisconnect: async ({ documentName, instance }) => {
+      if (isMetaRoom(documentName)) return;
+
       const doc = instance.documents.get(documentName) as Y.Doc | undefined;
-      if (!doc) {
-        return;
-      }
+      if (!doc) return;
 
       const state = Y.encodeStateAsUpdate(doc);
-      if (!state || state.length === 0) {
-        return;
-      }
+      if (!state || state.length === 0) return;
 
       logger.info(`[disconnect] force saving: ${documentName}, ${state.length} bytes`);
       try {
-        await persistDocument(pool, documentName, state, logger);
+        await persistDocument(pool, server.hocuspocus, documentName, state, doc, logger);
         logger.debug(`[disconnect] force saved: ${documentName}`);
       } catch (err) {
         logger.error(`[disconnect] force save failed for "${documentName}": ${err}`);
@@ -252,6 +665,142 @@ export function createCollabServer(config: CollabServerConfig) {
     },
     extensions: [],
   });
+
+  const listenUrl = config.databaseUrl;
+  if (listenUrl) {
+    let listenClient: Client | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconnectAttempts = 0;
+    const stopped = false;
+    const MAX_RECONNECT_DELAY = 30000;
+
+    async function handlePageRenamed(
+      workspaceId: string,
+      pageId: string,
+      newTitle: string,
+    ): Promise<void> {
+      const metaRoomName = `${META_ROOM_PREFIX}${workspaceId}`;
+      const conn = await server.hocuspocus.openDirectConnection(metaRoomName, {});
+      try {
+        await conn.transact((metaDoc: Y.Doc) => {
+          const pageIndex = metaDoc.getMap('pageIndex');
+          const existing = pageIndex.get(pageId) as
+            | { title: string; icon: string | null; parentId: string | null; position: string }
+            | undefined;
+          if (existing) {
+            pageIndex.set(pageId, { ...existing, title: newTitle });
+          }
+
+          metaDoc.getMap('backlinksVersion').set(pageId, Date.now());
+        });
+      } finally {
+        await conn.disconnect();
+      }
+
+      const activeDoc = server.hocuspocus.documents.get(pageId) as Y.Doc | undefined;
+      if (activeDoc) {
+        const beforeTitle = activeDoc.getText('title').toString();
+        if (beforeTitle !== newTitle) {
+          activeDoc.transact(() => {
+            const titleText = activeDoc.getText('title');
+            titleText.delete(0, titleText.length);
+            titleText.insert(0, newTitle);
+          });
+          logger.debug(
+            `[listen] pushed rename to active session for page ${pageId}: "${beforeTitle}" -> "${newTitle}"`,
+          );
+        }
+      }
+
+      logger.debug(`[listen] updated meta for renamed page ${pageId} -> ${newTitle}`);
+    }
+
+    async function handlePageDeleted(workspaceId: string, pageId: string): Promise<void> {
+      const metaRoomName = `${META_ROOM_PREFIX}${workspaceId}`;
+      const conn = await server.hocuspocus.openDirectConnection(metaRoomName, {});
+      try {
+        await conn.transact((metaDoc: Y.Doc) => {
+          metaDoc.getMap('pageIndex').delete(pageId);
+          metaDoc.getMap('backlinksVersion').set(pageId, Date.now());
+        });
+      } finally {
+        await conn.disconnect();
+      }
+
+      logger.debug(`[listen] removed deleted page ${pageId} from meta room`);
+    }
+
+    function scheduleReconnect() {
+      if (stopped) return;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      const delay = Math.min(1000 * 2 ** reconnectAttempts, MAX_RECONNECT_DELAY);
+      reconnectAttempts += 1;
+      reconnectTimer = setTimeout(connectListenClient, delay);
+    }
+
+    async function connectListenClient(): Promise<void> {
+      if (stopped) return;
+
+      // Clean up existing client if any
+      if (listenClient) {
+        try {
+          listenClient.end();
+        } catch {
+          // ignore cleanup errors
+        }
+        listenClient = null;
+      }
+
+      try {
+        const client = new Client({ connectionString: listenUrl });
+        await client.connect();
+        await client.query('LISTEN page_renamed');
+        await client.query('LISTEN page_deleted');
+
+        client.on('notification', (msg) => {
+          try {
+            const payload = JSON.parse(msg.payload ?? '{}') as {
+              workspaceId?: string;
+              pageId?: string;
+              newTitle?: string;
+            };
+            const { workspaceId, pageId, newTitle } = payload;
+            if (!workspaceId || !pageId) return;
+
+            if (msg.channel === 'page_deleted') {
+              handlePageDeleted(workspaceId, pageId);
+            } else if (msg.channel === 'page_renamed' && newTitle) {
+              handlePageRenamed(workspaceId, pageId, newTitle);
+            }
+          } catch (err) {
+            logger.error(`[listen] failed to process notification: ${err}`);
+          }
+        });
+
+        client.on('error', (err) => {
+          logger.error(`[listen] client error: ${err.message}`);
+          scheduleReconnect();
+        });
+
+        client.on('end', () => {
+          logger.warn('[listen] client connection ended');
+          scheduleReconnect();
+        });
+
+        listenClient = client;
+        reconnectAttempts = 0;
+        logger.info('[listen] subscribed to page_renamed and page_deleted');
+      } catch (err) {
+        logger.error(`[listen] connection failed: ${err}`);
+        listenClient = null;
+        scheduleReconnect();
+      }
+    }
+
+    connectListenClient();
+  } else {
+    logger.warn('[listen] DATABASE_URL not configured — pg_notify subscriptions disabled');
+  }
 
   return server;
 }

--- a/packages/collab/src/server.ts
+++ b/packages/collab/src/server.ts
@@ -768,9 +768,13 @@ export function createCollabServer(config: CollabServerConfig) {
             if (!workspaceId || !pageId) return;
 
             if (msg.channel === 'page_deleted') {
-              handlePageDeleted(workspaceId, pageId);
+              void handlePageDeleted(workspaceId, pageId).catch((err) =>
+                logger.error(`[listen] handlePageDeleted failed: ${err}`),
+              );
             } else if (msg.channel === 'page_renamed' && newTitle) {
-              handlePageRenamed(workspaceId, pageId, newTitle);
+              void handlePageRenamed(workspaceId, pageId, newTitle).catch((err) =>
+                logger.error(`[listen] handlePageRenamed failed: ${err}`),
+              );
             }
           } catch (err) {
             logger.error(`[listen] failed to process notification: ${err}`);

--- a/packages/collab/src/server.ts
+++ b/packages/collab/src/server.ts
@@ -671,7 +671,7 @@ export function createCollabServer(config: CollabServerConfig) {
     let listenClient: Client | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let reconnectAttempts = 0;
-    const stopped = false;
+    let stopped = false;
     const MAX_RECONNECT_DELAY = 30000;
 
     async function handlePageRenamed(
@@ -802,6 +802,28 @@ export function createCollabServer(config: CollabServerConfig) {
     }
 
     connectListenClient();
+
+    // Clean up the listen client and reconnect timers when the server is
+    // destroyed (e.g. graceful shutdown or test teardown). Without this,
+    // the dangling pg.Client and its timers would leak and keep retrying.
+    const origDestroy = server.destroy.bind(server);
+    Object.defineProperty(server, 'destroy', {
+      value() {
+        stopped = true;
+        if (reconnectTimer) clearTimeout(reconnectTimer);
+        if (listenClient) {
+          try {
+            listenClient.end();
+          } catch {
+            // ignore cleanup errors
+          }
+          listenClient = null;
+        }
+        return origDestroy();
+      },
+      writable: true,
+      configurable: true,
+    });
   } else {
     logger.warn('[listen] DATABASE_URL not configured — pg_notify subscriptions disabled');
   }

--- a/packages/collab/test/setup.ts
+++ b/packages/collab/test/setup.ts
@@ -11,19 +11,33 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
-beforeEach(async () => {
-  await pool.query('SET session_replication_role = replica');
-  await pool.query(`
-    DO $$ DECLARE t RECORD;
-    BEGIN
-      FOR t IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
-      LOOP
-        EXECUTE 'TRUNCATE TABLE ' || quote_ident(t.tablename) || ' RESTART IDENTITY CASCADE';
-      END LOOP;
-    END $$;
-  `);
-  await pool.query('SET session_replication_role = default');
-});
+async function truncateTables(): Promise<void> {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await pool.query('SET session_replication_role = replica');
+      await pool.query(`
+        DO $$ DECLARE t RECORD;
+        BEGIN
+          FOR t IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
+          LOOP
+            EXECUTE 'TRUNCATE TABLE ' || quote_ident(t.tablename) || ' RESTART IDENTITY CASCADE';
+          END LOOP;
+        END $$;
+      `);
+      await pool.query('SET session_replication_role = default');
+      return;
+    } catch (err) {
+      const pgErr = err as { code?: string } | undefined;
+      if (pgErr?.code === '40P01' && attempt < 3) {
+        await new Promise((r) => setTimeout(r, 100 * attempt));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+beforeEach(truncateTables);
 
 afterEach(() => {
   vi.restoreAllMocks();

--- a/packages/collab/test/setup.ts
+++ b/packages/collab/test/setup.ts
@@ -15,17 +15,20 @@ async function truncateTables(): Promise<void> {
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       await pool.query('SET session_replication_role = replica');
-      await pool.query(`
-        DO $$ DECLARE t RECORD;
-        BEGIN
-          FOR t IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
-          LOOP
-            EXECUTE 'TRUNCATE TABLE ' || quote_ident(t.tablename) || ' RESTART IDENTITY CASCADE';
-          END LOOP;
-        END $$;
-      `);
-      await pool.query('SET session_replication_role = default');
-      return;
+      try {
+        await pool.query(`
+          DO $$ DECLARE t RECORD;
+          BEGIN
+            FOR t IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public')
+            LOOP
+              EXECUTE 'TRUNCATE TABLE ' || quote_ident(t.tablename) || ' RESTART IDENTITY CASCADE';
+            END LOOP;
+          END $$;
+        `);
+        return;
+      } finally {
+        await pool.query('SET session_replication_role = default');
+      }
     } catch (err) {
       const pgErr = err as { code?: string } | undefined;
       if (pgErr?.code === '40P01' && attempt < 3) {

--- a/packages/shared/src/utils/yjs-helpers.ts
+++ b/packages/shared/src/utils/yjs-helpers.ts
@@ -1,10 +1,30 @@
 import * as Y from 'yjs';
 
+export type ConnectionTargetType = 'page' | 'tag' | 'user' | 'external';
+export type ConnectionType = 'wikilink' | 'tag' | 'mention' | 'embed' | 'heading' | 'url';
+
+export interface ConnectionDraft {
+  targetType: ConnectionTargetType;
+  targetId?: string;
+  targetSlug: string;
+  targetLabel: string;
+  connectionType: ConnectionType;
+  linkText?: string;
+  linkContext?: string;
+}
+
 export function yDocToMarkdown(update: Uint8Array): string {
   const doc = new Y.Doc();
   Y.applyUpdate(doc, update);
   const fragment = doc.getXmlFragment('prosemirror');
   return xmlElementToMarkdown(fragment);
+}
+
+export function extractConnectionsFromYDoc(update: Uint8Array): ConnectionDraft[] {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, update);
+  const fragment = doc.getXmlFragment('prosemirror');
+  return extractConnectionsFromXml(fragment);
 }
 
 function xmlElementToMarkdown(element: Y.XmlFragment | Y.XmlElement): string {
@@ -39,11 +59,18 @@ function xmlElementToMarkdown(element: Y.XmlFragment | Y.XmlElement): string {
         case 'wikiLink': {
           const path = item.getAttribute('path') || '';
           const label = item.getAttribute('label') || '';
+          const heading = item.getAttribute('heading') || '';
+          const target = heading ? `${path}#${heading}` : path;
           if (path === label) {
-            markdown += `[[${path}]]`;
+            markdown += `[[${target}]]`;
           } else {
-            markdown += `[[${path}|${label}]]`;
+            markdown += `[[${target}|${label}]]`;
           }
+          break;
+        }
+        case 'tag': {
+          const name = item.getAttribute('name') || item.getAttribute('value') || '';
+          markdown += name ? `#${name}` : '';
           break;
         }
         case 'inlineCode':
@@ -59,6 +86,111 @@ function xmlElementToMarkdown(element: Y.XmlFragment | Y.XmlElement): string {
   }
 
   return markdown;
+}
+
+function extractConnectionsFromXml(element: Y.XmlFragment | Y.XmlElement): ConnectionDraft[] {
+  const connections: ConnectionDraft[] = [];
+
+  for (let i = 0; i < element.length; i++) {
+    const item = element.get(i);
+    if (!(item instanceof Y.XmlElement)) continue;
+
+    const context = xmlElementPlainText(item).trim();
+    collectConnections(item, context, connections);
+  }
+
+  return connections;
+}
+
+function collectConnections(
+  element: Y.XmlElement,
+  context: string,
+  connections: ConnectionDraft[],
+): void {
+  for (let i = 0; i < element.length; i++) {
+    const item = element.get(i);
+    if (!(item instanceof Y.XmlElement)) continue;
+
+    if (item.nodeName === 'wikiLink') {
+      const path = item.getAttribute('path') || '';
+      const label = item.getAttribute('label') || path;
+      const targetId = item.getAttribute('targetId') || '';
+      const heading = item.getAttribute('heading') || '';
+      const target = heading ? `${path}#${heading}` : path;
+      const targetSlug = normalizePageSlug(path);
+
+      if (targetSlug) {
+        const draft: ConnectionDraft = {
+          targetType: 'page',
+          targetSlug,
+          targetLabel: target || label,
+          connectionType: heading ? 'heading' : 'wikilink',
+          linkText: label || target || path,
+        };
+        if (context) draft.linkContext = context;
+        if (targetId) draft.targetId = targetId;
+        connections.push(draft);
+      }
+      continue;
+    }
+
+    if (item.nodeName === 'tag') {
+      const name = item.getAttribute('name') || item.getAttribute('value') || '';
+      const tagSlug = normalizeTagSlug(name);
+      if (tagSlug) {
+        connections.push({
+          targetType: 'tag',
+          targetSlug: tagSlug,
+          targetLabel: tagSlug,
+          connectionType: 'tag',
+          linkText: tagSlug,
+          ...(context ? { linkContext: context } : {}),
+        });
+      }
+      continue;
+    }
+
+    collectConnections(item, context, connections);
+  }
+}
+
+function xmlElementPlainText(element: Y.XmlFragment | Y.XmlElement): string {
+  let text = '';
+
+  for (let i = 0; i < element.length; i++) {
+    const item = element.get(i);
+    if (item instanceof Y.XmlText) {
+      text += item.toString();
+      continue;
+    }
+
+    if (!(item instanceof Y.XmlElement)) continue;
+
+    if (item.nodeName === 'wikiLink') {
+      const label = item.getAttribute('label') || item.getAttribute('path') || '';
+      text += label;
+      continue;
+    }
+
+    if (item.nodeName === 'tag') {
+      const name = item.getAttribute('name') || item.getAttribute('value') || '';
+      text += name ? `#${name}` : '';
+      continue;
+    }
+
+    text += xmlElementPlainText(item);
+  }
+
+  return text;
+}
+
+export function normalizePageSlug(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function normalizeTagSlug(value: string): string {
+  const trimmed = value.trim().replace(/^#+/, '').toLowerCase();
+  return trimmed ? `#${trimmed}` : '';
 }
 
 const WIKILINK_REGEX = /(?<!!)\[\[([^#|\]]+)(?:#(\^[^|]+)|#([^|\]]+))?(?:\|([^\]]+))?\]\]/g;

--- a/packages/shared/src/utils/yjs-helpers.unit.test.ts
+++ b/packages/shared/src/utils/yjs-helpers.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { extractConnectionsFromYDoc, yDocToMarkdown } from './yjs-helpers';
+
+function encodeFragment(children: Y.XmlElement[]): Uint8Array {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment('prosemirror');
+  fragment.push(children);
+  return Y.encodeStateAsUpdate(doc);
+}
+
+function paragraph(children: (Y.XmlElement | Y.XmlText)[]): Y.XmlElement {
+  const node = new Y.XmlElement('paragraph');
+  node.push(children);
+  return node;
+}
+
+function text(value: string): Y.XmlText {
+  return new Y.XmlText(value);
+}
+
+describe('yjs helpers', () => {
+  it('serializes tag nodes to markdown', () => {
+    const tag = new Y.XmlElement('tag');
+    tag.setAttribute('name', 'Project');
+    const update = encodeFragment([paragraph([text('Track '), tag])]);
+
+    expect(yDocToMarkdown(update)).toBe('Track #Project\n\n');
+  });
+
+  it('extracts page and tag connections from Yjs documents', () => {
+    const link = new Y.XmlElement('wikiLink');
+    link.setAttribute('targetId', '11111111-1111-1111-1111-111111111111');
+    link.setAttribute('path', 'Roadmap');
+    link.setAttribute('label', 'Roadmap');
+
+    const tag = new Y.XmlElement('tag');
+    tag.setAttribute('name', 'Project');
+
+    const update = encodeFragment([paragraph([text('See '), link, text(' for '), tag])]);
+
+    expect(extractConnectionsFromYDoc(update)).toEqual([
+      {
+        targetType: 'page',
+        targetId: '11111111-1111-1111-1111-111111111111',
+        targetSlug: 'roadmap',
+        targetLabel: 'Roadmap',
+        connectionType: 'wikilink',
+        linkText: 'Roadmap',
+        linkContext: 'See Roadmap for #Project',
+      },
+      {
+        targetType: 'tag',
+        targetSlug: '#project',
+        targetLabel: '#project',
+        connectionType: 'tag',
+        linkText: '#project',
+        linkContext: 'See Roadmap for #Project',
+      },
+    ]);
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
               <Route path=":workspaceSlug" element={<Workspace />} />
               <Route path=":workspaceSlug/folder/:folderId" element={<Workspace />} />
               <Route path=":workspaceSlug/settings" element={<WorkspaceSettings />} />
-              <Route path=":workspaceSlug/:pageId" element={<Page />} />
+              <Route path=":workspaceSlug/:slugAndId" element={<Page />} />
             </Route>
             <Route path="/public/:token" element={<PublicPage />} />
 

--- a/packages/web/src/components/AppShell.tsx
+++ b/packages/web/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import { useWorkspaces } from '../hooks/use-workspaces';
 import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
 import { useSidebarCollapsed } from '../hooks/useSidebarCollapsed';
+import { useWorkspaceMeta } from '../hooks/useWorkspaceMeta';
 import { CommandPalette } from './CommandPalette';
 import { ProfilePill } from './ProfilePill';
 import { Sidebar } from './Sidebar';
@@ -21,6 +22,8 @@ export function AppShell() {
   const workspace = workspaces?.find((item) => item.slug === workspaceSlug);
 
   useKeyboardShortcuts({ toggleSidebar: toggleCollapsed });
+
+  useWorkspaceMeta(workspace?.id);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: location.pathname triggers mobile menu close on navigation
   useEffect(() => {

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -204,12 +204,12 @@ export function MilkdownEditor({
       forceSyncInterval: 2000,
       token: async () => {
         const cached = cachedTokenRef.current;
+        if (cached && Date.now() < cached.expiresAt) {
+          return cached.token;
+        }
         const session = await authClient.getSession();
         const token = session.data?.session?.token ?? '';
         const userId = session.data?.user?.id ?? '';
-        if (cached && cached.userId === userId && Date.now() < cached.expiresAt) {
-          return cached.token;
-        }
         cachedTokenRef.current = { token, userId, expiresAt: Date.now() + 5 * 60 * 1000 };
         return token;
       },

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -41,6 +41,15 @@ interface MilkdownEditorProps {
 
 const COLLAB_URL = import.meta.env.VITE_COLLAB_URL ?? 'ws://localhost:1234';
 
+function execEditorAction(editor: Editor | null, fn: (ctx: unknown) => void): void {
+  if (!editor) return;
+  try {
+    editor.action(fn);
+  } catch {
+    /* Editor may have been destroyed */
+  }
+}
+
 export function MilkdownEditor({
   pageId,
   workspaceId,
@@ -182,6 +191,11 @@ export function MilkdownEditor({
     }
   }, [hasMark, hasBlockType, hasParentBlockType]);
 
+  // Cache the collab session token so HocuspocusProvider reconnection
+  // doesn't fire a redundant get-session API call on every retry.
+  // Key the cache by user ID to avoid session fixation on shared machines.
+  const cachedTokenRef = useRef<{ token: string; userId: string; expiresAt: number } | null>(null);
+
   const provider = useMemo(() => {
     const instance = new HocuspocusProvider({
       url: COLLAB_URL,
@@ -189,8 +203,15 @@ export function MilkdownEditor({
       document: doc,
       forceSyncInterval: 2000,
       token: async () => {
+        const cached = cachedTokenRef.current;
         const session = await authClient.getSession();
-        return session.data?.session?.token ?? '';
+        const token = session.data?.session?.token ?? '';
+        const userId = session.data?.user?.id ?? '';
+        if (cached && cached.userId === userId && Date.now() < cached.expiresAt) {
+          return cached.token;
+        }
+        cachedTokenRef.current = { token, userId, expiresAt: Date.now() + 5 * 60 * 1000 };
+        return token;
       },
     });
 

--- a/packages/web/src/components/editor/PageTitle.test.tsx
+++ b/packages/web/src/components/editor/PageTitle.test.tsx
@@ -14,7 +14,11 @@ const mockUsePageTitle = vi.mocked(usePageTitle);
 
 describe('PageTitle', () => {
   beforeEach(() => {
-    mockUsePageTitle.mockReturnValue({ title: 'Test Page', setTitle: vi.fn() });
+    mockUsePageTitle.mockReturnValue({
+      title: 'Test Page',
+      setTitle: vi.fn(),
+      commitTitle: vi.fn(),
+    });
   });
 
   afterEach(() => {
@@ -31,7 +35,7 @@ describe('PageTitle', () => {
   it('calls setTitle on user input', async () => {
     function Wrapper() {
       const [title, setTitle] = useState('Test Page');
-      mockUsePageTitle.mockReturnValue({ title, setTitle });
+      mockUsePageTitle.mockReturnValue({ title, setTitle, commitTitle: vi.fn() });
       return <PageTitle pageId="p1" initialTitle="Test Page" />;
     }
 

--- a/packages/web/src/components/editor/PageTitle.tsx
+++ b/packages/web/src/components/editor/PageTitle.tsx
@@ -1,19 +1,33 @@
-import React from 'react';
+import type React from 'react';
+import { useCallback } from 'react';
+import type * as Y from 'yjs';
 import { usePageTitle } from '../../hooks/usePageTitle';
 
 interface PageTitleProps {
   pageId: string;
   initialTitle: string;
+  ydoc?: Y.Doc | null;
 }
 
-export function PageTitle({ pageId, initialTitle }: PageTitleProps) {
-  const { title, setTitle } = usePageTitle(pageId, initialTitle ?? 'Untitled');
+export function PageTitle({ pageId, initialTitle, ydoc }: PageTitleProps) {
+  const { title, setTitle, commitTitle } = usePageTitle(pageId, initialTitle ?? 'Untitled', ydoc);
+
+  const handleBlurOrEnter = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) => {
+      // Handle keyboard events (Enter) and blur events
+      if ('key' in e && e.key !== 'Enter') return;
+      commitTitle(title);
+    },
+    [title, commitTitle],
+  );
 
   return (
     <input
       type="text"
       value={title}
       onChange={(e) => setTitle(e.target.value)}
+      onBlur={handleBlurOrEnter}
+      onKeyDown={handleBlurOrEnter}
       className="w-full font-bold leading-tight text-zinc-900 dark:text-zinc-50 bg-transparent outline-none placeholder:text-zinc-300 dark:placeholder:text-zinc-700 focus:ring-0 focus:border-transparent transition-colors break-words font-serif"
       placeholder="Page Title"
       autoComplete="off"

--- a/packages/web/src/components/editor/PageTitle.tsx
+++ b/packages/web/src/components/editor/PageTitle.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import type * as Y from 'yjs';
 import { usePageTitle } from '../../hooks/usePageTitle';
 
@@ -11,18 +11,20 @@ interface PageTitleProps {
 
 export function PageTitle({ pageId, initialTitle, ydoc }: PageTitleProps) {
   const { title, setTitle, commitTitle } = usePageTitle(pageId, initialTitle ?? 'Untitled', ydoc);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleBlurOrEnter = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement> | React.FocusEvent<HTMLInputElement>) => {
-      // Handle keyboard events (Enter) and blur events
       if ('key' in e && e.key !== 'Enter') return;
-      commitTitle(title);
+      const liveValue = inputRef.current?.value ?? title;
+      commitTitle(liveValue);
     },
-    [title, commitTitle],
+    [commitTitle, title],
   );
 
   return (
     <input
+      ref={inputRef}
       type="text"
       value={title}
       onChange={(e) => setTitle(e.target.value)}

--- a/packages/web/src/editor/plugins/wikiLinkView.ts
+++ b/packages/web/src/editor/plugins/wikiLinkView.ts
@@ -65,7 +65,7 @@ const wikiLinkNodeView: NodeViewConstructor = (initialNode, view, getPos) => {
     const displayText = resolvedTitle || storedLabel || currentTargetId || 'wiki link';
     const pathDisplay = currentHeading ? `${displayText}#${currentHeading}` : displayText;
 
-    dom.textContent = displayText;
+    dom.textContent = pathDisplay;
     dom.dataset.targetId = currentTargetId || resolvedTargetId;
     dom.dataset.path = pathDisplay;
     dom.dataset.heading = currentHeading;
@@ -75,7 +75,9 @@ const wikiLinkNodeView: NodeViewConstructor = (initialNode, view, getPos) => {
     // extracts the correct slug on next persist, avoiding a stale-target
     // fallback lookup.
     const currentPath = node.attrs.path as string;
-    if (resolvedTitle && (currentPath !== resolvedTitle || storedLabel !== resolvedTitle)) {
+    if (resolvedTitle && currentPath !== resolvedTitle) {
+      // Only auto-update label when it was a default label (matched the old path),
+      // not when the user intentionally set a custom alias.
       const newLabel = storedLabel === currentPath ? resolvedTitle : storedLabel;
       const pos = getPos();
       if (typeof pos === 'number' && pos >= 0) {

--- a/packages/web/src/editor/plugins/wikiLinkView.ts
+++ b/packages/web/src/editor/plugins/wikiLinkView.ts
@@ -1,0 +1,122 @@
+import type { NodeViewConstructor } from '@milkdown/kit/prose/view';
+import { $view } from '@milkdown/utils';
+import { getPageIndexMap } from '../../hooks/useWorkspaceMeta';
+import { wikiLink } from './wikilink';
+
+const wikiLinkNodeView: NodeViewConstructor = (initialNode, view, getPos) => {
+  const dom = document.createElement('a');
+  dom.className = 'wiki-link';
+  dom.href = '#';
+
+  let node = initialNode;
+  let unsub: (() => void) | null = null;
+  let retryTimeout: ReturnType<typeof setTimeout> | null = null;
+  let renameTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function setupObserver() {
+    if (unsub) return;
+    const map = getPageIndexMap();
+    if (!map) {
+      retryTimeout = setTimeout(setupObserver, 100);
+      return;
+    }
+    const handler = () => updateDisplay();
+    map.observe(handler);
+    unsub = () => {
+      try {
+        map.unobserve(handler);
+      } catch {
+        /* already detached */
+      }
+    };
+    updateDisplay();
+  }
+
+  function updateDisplay() {
+    setupObserver();
+    const currentTargetId = node.attrs.targetId as string;
+    const currentHeading = node.attrs.heading as string;
+    const storedLabel = node.attrs.label as string;
+
+    const pageIndex = getPageIndexMap();
+    let resolvedTitle = '';
+    let resolvedTargetId = currentTargetId;
+
+    if (pageIndex) {
+      if (currentTargetId) {
+        const pageData = pageIndex.get(currentTargetId) as { title?: string } | undefined;
+        resolvedTitle = pageData?.title ?? '';
+      }
+
+      // Fallback: resolve by path/slug for manual wiki links without targetId.
+      if (!resolvedTitle && node.attrs.path) {
+        const path = String(node.attrs.path).toLowerCase();
+        for (const [id, data] of pageIndex.entries()) {
+          const pageData = data as { title?: string } | undefined;
+          if (pageData?.title && pageData.title.toLowerCase() === path) {
+            resolvedTitle = pageData.title;
+            resolvedTargetId = String(id);
+            break;
+          }
+        }
+      }
+    }
+
+    const displayText = resolvedTitle || storedLabel || currentTargetId || 'wiki link';
+    const pathDisplay = currentHeading ? `${displayText}#${currentHeading}` : displayText;
+
+    dom.textContent = displayText;
+    dom.dataset.targetId = currentTargetId || resolvedTargetId;
+    dom.dataset.path = pathDisplay;
+    dom.dataset.heading = currentHeading;
+
+    // When the target page is renamed, update the node attributes so the
+    // Yjs document contains the new path. This ensures the collab server
+    // extracts the correct slug on next persist, avoiding a stale-target
+    // fallback lookup.
+    const currentPath = node.attrs.path as string;
+    if (resolvedTitle && (currentPath !== resolvedTitle || storedLabel !== resolvedTitle)) {
+      const newLabel = storedLabel === currentPath ? resolvedTitle : storedLabel;
+      const pos = getPos();
+      if (typeof pos === 'number' && pos >= 0) {
+        const attrs: Record<string, unknown> = {
+          ...node.attrs,
+          path: resolvedTitle,
+          label: newLabel,
+        };
+        if (resolvedTargetId && !currentTargetId) {
+          attrs.targetId = resolvedTargetId;
+        }
+        if (renameTimeout) clearTimeout(renameTimeout);
+        // Delay to ensure the Milkdown collab plugin has finished binding
+        // the Yjs document before we mutate ProseMirror state.
+        renameTimeout = setTimeout(() => {
+          const tr = view.state.tr.setNodeMarkup(pos, undefined, attrs);
+          view.dispatch(tr);
+        }, 500);
+      }
+    }
+  }
+
+  requestAnimationFrame(() => {
+    setupObserver();
+  });
+
+  return {
+    dom,
+    update: (newNode) => {
+      if (newNode.type.name !== 'wikiLink') return false;
+      node = newNode;
+      updateDisplay();
+      return true;
+    },
+    destroy: () => {
+      if (retryTimeout) clearTimeout(retryTimeout);
+      if (renameTimeout) clearTimeout(renameTimeout);
+      unsub?.();
+    },
+    ignoreMutation: () => true,
+  };
+};
+
+export const wikiLinkView = $view(wikiLink, () => wikiLinkNodeView);

--- a/packages/web/src/editor/plugins/wikilink.ts
+++ b/packages/web/src/editor/plugins/wikilink.ts
@@ -1,10 +1,25 @@
 import { $node } from '@milkdown/utils';
+import { getPageIndexMap } from '../../hooks/useWorkspaceMeta';
+
+function resolveTargetId(path: string): string {
+  const pageIndex = getPageIndexMap();
+  if (!pageIndex || !path) return '';
+  const lowerPath = path.toLowerCase();
+  for (const [id, data] of pageIndex.entries()) {
+    const entry = data as { title?: string } | undefined;
+    if (entry?.title && entry.title.toLowerCase() === lowerPath) {
+      return id;
+    }
+  }
+  return '';
+}
 
 export const wikiLink = $node('wikiLink', () => ({
   group: 'inline',
   inline: true,
   atom: true,
   attrs: {
+    targetId: { default: '' },
     path: { default: '' },
     heading: { default: '' },
     label: { default: '' },
@@ -13,6 +28,7 @@ export const wikiLink = $node('wikiLink', () => ({
     {
       tag: 'a.wiki-link',
       getAttrs: (dom) => ({
+        targetId: (dom as HTMLElement).getAttribute('data-target-id') || '',
         path: (dom as HTMLElement).getAttribute('data-path'),
         heading: (dom as HTMLElement).getAttribute('data-heading') || '',
         label: dom.textContent,
@@ -24,6 +40,7 @@ export const wikiLink = $node('wikiLink', () => ({
     {
       class: 'wiki-link',
       href: '#',
+      'data-target-id': node.attrs.targetId || '',
       'data-path': node.attrs.path,
       'data-heading': node.attrs.heading || '',
     },
@@ -44,6 +61,7 @@ export const wikiLink = $node('wikiLink', () => ({
           path,
           heading,
           label,
+          targetId: resolveTargetId(path),
         });
       }
     },

--- a/packages/web/src/editor/utils/documentRepair.ts
+++ b/packages/web/src/editor/utils/documentRepair.ts
@@ -22,7 +22,7 @@ function buildWikiNode(wikiLinkType: NodeType, source: string): ProseNode {
   const heading = match?.[2] ?? '';
   const label = match?.[3] ?? (path ? (heading ? `${path}#${heading}` : path) : `#${heading}`);
 
-  return wikiLinkType.create({ path, heading, label });
+  return wikiLinkType.create({ targetId: '', path, heading, label });
 }
 
 function splitInlineText(

--- a/packages/web/src/hooks/use-backlinks.ts
+++ b/packages/web/src/hooks/use-backlinks.ts
@@ -46,8 +46,8 @@ export function useBacklinks(pageId?: string) {
       return fetchBacklinks(pageId);
     },
     enabled: !!pageId,
-    staleTime: 1000 * 60 * 2,
-    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -59,7 +59,7 @@ export function useOutgoingLinks(pageId?: string) {
       return fetchOutgoingLinks(pageId);
     },
     enabled: !!pageId,
-    staleTime: 1000 * 60 * 2,
-    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 }

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -28,6 +28,7 @@ import {
   toggleLatexCommand,
 } from '../editor/plugins/math';
 import { tag } from '../editor/plugins/tag';
+import { wikiLinkView } from '../editor/plugins/wikiLinkView';
 import { wikiLink } from '../editor/plugins/wikilink';
 import { repairDocument } from '../editor/utils/documentRepair';
 import 'katex/dist/katex.min.css';
@@ -405,15 +406,30 @@ export function useMilkdown({
                   event.preventDefault();
                   event.stopPropagation();
 
-                  const path = anchor.getAttribute('data-path') || '';
-                  const heading = anchor.getAttribute('data-heading') || '';
-
                   linkEditor.close();
 
-                  if (path && onWikiLinkClickRef.current) {
-                    onWikiLinkClickRef.current(path);
-                  } else if (heading) {
-                    scrollToHeading(heading);
+                  // Resolve by UUID first (stable across renames), fall back to
+                  // title-based path matching for legacy links without targetId.
+                  const targetId = anchor.getAttribute('data-target-id') || '';
+                  if (targetId && onWikiLinkClickRef.current) {
+                    // handleWikiLinkClick checks p.id === targetId, which is a
+                    // UUID match — resilient to title changes.
+                    onWikiLinkClickRef.current(targetId);
+                  } else {
+                    const path = anchor.getAttribute('data-path') || '';
+                    const heading = anchor.getAttribute('data-heading') || '';
+                    // Strip #heading suffix from path if present, since
+                    // handleWikiLinkClick resolves by title match and a
+                    // "#Heading" suffix would never match a page title.
+                    const pagePath =
+                      heading && path.endsWith(`#${heading}`)
+                        ? path.slice(0, -(heading.length + 1))
+                        : path;
+                    if (pagePath && onWikiLinkClickRef.current) {
+                      onWikiLinkClickRef.current(pagePath);
+                    } else if (heading) {
+                      scrollToHeading(heading);
+                    }
                   }
                   return true;
                 }
@@ -466,43 +482,7 @@ export function useMilkdown({
                 if (!(anchor instanceof HTMLAnchorElement)) return false;
 
                 if (anchor.classList.contains('wiki-link')) {
-                  const path = anchor.getAttribute('data-path') || '';
-                  const heading = anchor.getAttribute('data-heading') || '';
-                  const displayText = heading
-                    ? path
-                      ? `${path}#${heading}`
-                      : `#${heading}`
-                    : path || 'Wiki link';
-
-                  const pos = view.posAtDOM(anchor, 0);
-                  let wikiNode = view.state.doc.nodeAt(pos);
-                  let from = pos;
-                  let to = pos;
-                  if (wikiNode && wikiNode.type.name === 'wikiLink') {
-                    to = pos + wikiNode.nodeSize;
-                  } else {
-                    wikiNode = view.state.doc.nodeAt(pos - 1);
-                    if (wikiNode && wikiNode.type.name === 'wikiLink') {
-                      from = pos - 1;
-                      to = from + wikiNode.nodeSize;
-                    } else {
-                      return false;
-                    }
-                  }
-
-                  linkEditor.open(view, anchor, {
-                    initialUrl: displayText,
-                    initialText: anchor.textContent || displayText,
-                    onConfirm: ({ text }) => {
-                      const tr = view.state.tr;
-                      tr.setNodeMarkup(from, undefined, { ...wikiNode.attrs, label: text });
-                      view.dispatch(tr);
-                    },
-                    onRemove: () => {
-                      const tr = view.state.tr.delete(from, to);
-                      view.dispatch(tr);
-                    },
-                  });
+                  // Wiki links resolve automatically — no link editor needed.
                   return true;
                 }
 
@@ -553,6 +533,7 @@ export function useMilkdown({
         .use(commonmark)
         .use(gfm)
         .use(wikiLink)
+        .use(wikiLinkView)
         .use(callout)
         .use(tag)
         .use(autolink)
@@ -628,6 +609,7 @@ export function useMilkdown({
           | undefined;
         if (view) {
           setTimeout(() => {
+            if (disposed) return;
             repairDocument(view);
           }, 500);
         }
@@ -638,6 +620,17 @@ export function useMilkdown({
 
     return () => {
       disposed = true;
+      // Disconnect collab before destroying the editor so Yjs updates
+      // arriving as the WebSocket closes don't dispatch on destroyed context
+      if (hasCollab && runtimeEditor) {
+        try {
+          runtimeEditor.action((ctx) => {
+            ctx.get(collabServiceCtx).disconnect();
+          });
+        } catch {
+          // Editor or collab already torn down
+        }
+      }
       runtimeEditor?.destroy();
       editorRef.current = null;
       setEditorInstance(null);

--- a/packages/web/src/hooks/usePageTitle.test.ts
+++ b/packages/web/src/hooks/usePageTitle.test.ts
@@ -61,9 +61,9 @@ describe('usePageTitle', () => {
     });
 
     act(() => {
-      result.current.setTitle('First');
-      result.current.setTitle('Second');
-      result.current.setTitle('Final');
+      result.current.commitTitle('First');
+      result.current.commitTitle('Second');
+      result.current.commitTitle('Final');
     });
 
     await waitFor(

--- a/packages/web/src/hooks/usePageTitle.ts
+++ b/packages/web/src/hooks/usePageTitle.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type * as Y from 'yjs';
 
 const API_BASE = '/api';
 
@@ -19,11 +20,29 @@ function normalizeTitle(value: string): string {
   return trimmed.length > 0 ? trimmed : 'Untitled';
 }
 
-export function usePageTitle(pageId?: string, initialTitle?: string) {
+export function usePageTitle(pageId?: string, initialTitle?: string, ydoc?: Y.Doc | null) {
   const [title, setTitle] = useState(initialTitle ?? 'Untitled');
   const queryClient = useQueryClient();
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSavedTitleRef = useRef('Untitled');
+  const ydocRef = useRef(ydoc);
+  ydocRef.current = ydoc;
+
+  // Listen for title changes from Yjs (sync from other clients or offline reconnect)
+  useEffect(() => {
+    if (!ydoc) return undefined;
+
+    const titleText = ydoc.getText('title');
+    const observer = () => {
+      const newTitle = titleText.toString() || 'Untitled';
+      setTitle(newTitle);
+      lastSavedTitleRef.current = newTitle;
+    };
+    titleText.observe(observer);
+
+    return () => {
+      titleText.unobserve(observer);
+    };
+  }, [ydoc]);
 
   useEffect(() => {
     if (typeof initialTitle === 'string') {
@@ -43,33 +62,28 @@ export function usePageTitle(pageId?: string, initialTitle?: string) {
     },
   });
 
-  useEffect(() => {
-    if (!pageId) {
-      return undefined;
-    }
-    const nextTitle = normalizeTitle(title);
+  const commitTitle = useCallback(
+    (newTitle: string) => {
+      const nextTitle = normalizeTitle(newTitle);
+      if (nextTitle === lastSavedTitleRef.current) return;
 
-    if (nextTitle === lastSavedTitleRef.current) {
-      return undefined;
-    }
+      // Write to Yjs doc for offline queue and real-time sync
+      const currentDoc = ydocRef.current;
+      if (currentDoc) {
+        const titleText = currentDoc.getText('title');
+        titleText.delete(0, titleText.length);
+        titleText.insert(0, nextTitle);
+      }
 
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-    }
-    debounceRef.current = setTimeout(() => {
+      // Send PATCH for DB column update (fast-path cache)
       mutation.mutate(nextTitle, {
         onSuccess: () => {
           lastSavedTitleRef.current = nextTitle;
         },
       });
-    }, 1000);
+    },
+    [mutation],
+  );
 
-    return () => {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-    };
-  }, [mutation, pageId, title]);
-
-  return { title, setTitle };
+  return { title, setTitle, commitTitle };
 }

--- a/packages/web/src/hooks/useWikiLinkSuggestions.ts
+++ b/packages/web/src/hooks/useWikiLinkSuggestions.ts
@@ -1,6 +1,5 @@
 import type { Editor } from '@milkdown/core';
 import { editorViewCtx } from '@milkdown/core';
-import { useQueryClient } from '@tanstack/react-query';
 import { Selection } from 'prosemirror-state';
 import { useCallback, useRef, useState } from 'react';
 import { useCreatePage, usePages } from './use-pages';
@@ -22,7 +21,6 @@ export function useWikiLinkSuggestions(
   workspaceId: string,
   editorRef: React.RefObject<Editor | null>,
 ) {
-  const queryClient = useQueryClient();
   const createPageMutation = useCreatePage();
   const { data: allPages = [] } = usePages(workspaceId);
 
@@ -64,47 +62,49 @@ export function useWikiLinkSuggestions(
       const editor = editorRef.current;
       if (!editor) return;
 
-      editor.action((ctx) => {
-        const view = ctx.get(editorViewCtx);
-        const { state, dispatch } = view;
-        const { selection } = state;
-        const { $from } = selection;
+      try {
+        editor.action((ctx) => {
+          const view = ctx.get(editorViewCtx);
+          if (!view) return;
+          const { state, dispatch } = view;
+          const { selection } = state;
+          const { $from } = selection;
 
-        const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, '\ufffc');
-        const match = textBefore.match(/\[\[([^\]]*)$/);
+          const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, '\ufffc');
+          const match = textBefore.match(/\[\[([^\]]*)$/);
 
-        if (match) {
-          const start = $from.pos - match[0].length;
-          const end = $from.pos;
+          if (match) {
+            const start = $from.pos - match[0].length;
+            const end = $from.pos;
 
-          const wikiLinkNode = state.schema.nodes.wikiLink;
-          if (wikiLinkNode) {
-            const tr = state.tr.replaceWith(
-              start,
-              end,
-              wikiLinkNode.create({
-                path: page.title,
-                label: page.title,
-              }),
-            );
+            const wikiLinkNode = state.schema.nodes.wikiLink;
+            if (wikiLinkNode) {
+              const tr = state.tr.replaceWith(
+                start,
+                end,
+                wikiLinkNode.create({
+                  targetId: page.id,
+                  path: page.title,
+                  label: page.title,
+                }),
+              );
 
-            const nextPos = start + 1;
-            const $pos = tr.doc.resolve(nextPos);
-            tr.setSelection(Selection.near($pos));
+              const nextPos = start + 1;
+              const $pos = tr.doc.resolve(nextPos);
+              tr.setSelection(Selection.near($pos));
 
-            dispatch(tr);
-            view.focus();
-
-            setTimeout(() => {
-              queryClient.invalidateQueries({ queryKey: ['backlinks'] });
-            }, 1000);
+              dispatch(tr);
+              view.focus();
+            }
           }
-        }
-      });
+        });
+      } catch {
+        // Editor may have been destroyed
+      }
 
       setSuggestions((prev) => ({ ...prev, isOpen: false }));
     },
-    [editorRef, queryClient],
+    [editorRef],
   );
 
   const handleAddPage = useCallback(

--- a/packages/web/src/hooks/useWorkspaceMeta.ts
+++ b/packages/web/src/hooks/useWorkspaceMeta.ts
@@ -1,0 +1,115 @@
+import { HocuspocusProvider } from '@hocuspocus/provider';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import * as Y from 'yjs';
+import { authClient } from '../lib/auth-client';
+
+const COLLAB_URL = import.meta.env.VITE_COLLAB_URL ?? 'ws://localhost:1234';
+const META_ROOM_PREFIX = 'workspace-meta:';
+
+/**
+ * Module-level reference to the current workspace's pageIndex Y.Map.
+ *
+ * Set by `useWorkspaceMeta` when the meta room connects, read by the
+ * wiki link node view to resolve targetId → current title at render time.
+ *
+ * A generation counter prevents the effect cleanup from nulling the map
+ * during a workspace switch (where React runs cleanup before the new
+ * effect). The generation is bumped during render via a ref comparison,
+ * so it reflects the incoming workspace before the old cleanup executes.
+ */
+let _pageIndex: Y.Map<unknown> | null = null;
+
+export function getPageIndexMap(): Y.Map<unknown> | null {
+  return _pageIndex;
+}
+
+/**
+ * Connects to the workspace meta room (a shared Yjs document indexed by
+ * workspace ID) that contains:
+ *   - `pageIndex`: a map of `{ pageId → { title, icon, parentId, position } }`
+ *   - `backlinksVersion`: a map of `{ pageId → timestamp }` bumped whenever
+ *     a page's connections are rebuilt, so clients can refetch backlinks.
+ *
+ * The meta room is populated server-side by `updateWorkspaceMeta()` and
+ * `updateBacklinksVersion()` on every page persist.
+ */
+export function useWorkspaceMeta(workspaceId: string | undefined) {
+  const queryClient = useQueryClient();
+
+  // Bump a generation counter during render whenever workspaceId changes.
+  // This runs before effect cleanups, so on workspace switch the old
+  // effect's cleanup sees a generation mismatch and skips nulling _pageIndex.
+  const workspaceGenRef = useRef(0);
+  const prevWorkspaceRef = useRef(workspaceId);
+  if (prevWorkspaceRef.current !== workspaceId) {
+    prevWorkspaceRef.current = workspaceId;
+    workspaceGenRef.current += 1;
+  }
+  const thisGen = workspaceGenRef.current;
+
+  useEffect(() => {
+    if (!workspaceId) return undefined;
+
+    const doc = new Y.Doc();
+    const provider = new HocuspocusProvider({
+      url: COLLAB_URL,
+      name: `${META_ROOM_PREFIX}${workspaceId}`,
+      document: doc,
+      token: async () => {
+        const session = await authClient.getSession();
+        return session.data?.session?.token ?? '';
+      },
+    });
+
+    const map = doc.getMap('pageIndex');
+    _pageIndex = map;
+
+    // Observe backlinksVersion bumps emitted by the collab server after
+    // every persist. When a version changes, invalidate TanStack Query
+    // for that page's backlinks and outgoing links so the panel refetches.
+    const bv = doc.getMap<number>('backlinksVersion');
+    const bvObserver = () => {
+      queryClient.invalidateQueries({ queryKey: ['backlinks'] });
+    };
+    bv.observe(bvObserver);
+
+    // Debounced page tree invalidation on pageIndex changes from the collab
+    // server, so the sidebar stays in sync across users.
+    const pageTreeTimerRef = { current: null as ReturnType<typeof setTimeout> | null };
+    const pageIndexInitialRef = { current: true };
+    const pageIndexObserver = () => {
+      if (pageIndexInitialRef.current) {
+        pageIndexInitialRef.current = false;
+        return;
+      }
+      if (pageTreeTimerRef.current) clearTimeout(pageTreeTimerRef.current);
+      pageTreeTimerRef.current = setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ['pageTree'] });
+      }, 1000);
+    };
+    map.observe(pageIndexObserver);
+
+    return () => {
+      // Only null _pageIndex on actual unmount, not on workspace switch.
+      // The generation was already bumped during render for the new
+      // workspace, so the cleanup sees a mismatch and skips nulling.
+      if (thisGen === workspaceGenRef.current) {
+        _pageIndex = null;
+      }
+      if (pageTreeTimerRef.current) clearTimeout(pageTreeTimerRef.current);
+      try {
+        bv.unobserve(bvObserver);
+      } catch {
+        // already detached
+      }
+      try {
+        map.unobserve(pageIndexObserver);
+      } catch {
+        // already detached
+      }
+      provider.destroy();
+      doc.destroy();
+    };
+  }, [workspaceId, queryClient, thisGen]);
+}

--- a/packages/web/src/hooks/useWorkspaceMeta.ts
+++ b/packages/web/src/hooks/useWorkspaceMeta.ts
@@ -13,10 +13,10 @@ const META_ROOM_PREFIX = 'workspace-meta:';
  * Set by `useWorkspaceMeta` when the meta room connects, read by the
  * wiki link node view to resolve targetId → current title at render time.
  *
- * A generation counter prevents the effect cleanup from nulling the map
- * during a workspace switch (where React runs cleanup before the new
- * effect). The generation is bumped during render via a ref comparison,
- * so it reflects the incoming workspace before the old cleanup executes.
+ * An effect-local ID (`effectIdRef`) prevents the cleanup from nulling
+ * the map during a workspace switch. The ID is bumped inside the effect
+ * (not during render), so it's safe under concurrent React — replayed
+ * renders can't corrupt it.
  */
 let _pageIndex: Y.Map<unknown> | null = null;
 
@@ -37,19 +37,16 @@ export function getPageIndexMap(): Y.Map<unknown> | null {
 export function useWorkspaceMeta(workspaceId: string | undefined) {
   const queryClient = useQueryClient();
 
-  // Bump a generation counter during render whenever workspaceId changes.
-  // This runs before effect cleanups, so on workspace switch the old
-  // effect's cleanup sees a generation mismatch and skips nulling _pageIndex.
-  const workspaceGenRef = useRef(0);
-  const prevWorkspaceRef = useRef(workspaceId);
-  if (prevWorkspaceRef.current !== workspaceId) {
-    prevWorkspaceRef.current = workspaceId;
-    workspaceGenRef.current += 1;
-  }
-  const thisGen = workspaceGenRef.current;
+  // Effect-local ID bumped inside the effect, not during render.
+  // On cleanup, only null _pageIndex when no new effect has started,
+  // which is safe under concurrent React (replayed renders can't
+  // cause a bump without a committed effect).
+  const effectIdRef = useRef(0);
 
   useEffect(() => {
     if (!workspaceId) return undefined;
+
+    const effectId = ++effectIdRef.current;
 
     const doc = new Y.Doc();
     const provider = new HocuspocusProvider({
@@ -91,10 +88,10 @@ export function useWorkspaceMeta(workspaceId: string | undefined) {
     map.observe(pageIndexObserver);
 
     return () => {
-      // Only null _pageIndex on actual unmount, not on workspace switch.
-      // The generation was already bumped during render for the new
-      // workspace, so the cleanup sees a mismatch and skips nulling.
-      if (thisGen === workspaceGenRef.current) {
+      // Only null _pageIndex when this is the last active effect.
+      // On a workspace switch, the new effect bumps the ref first,
+      // so this cleanup sees a mismatch and skips nulling.
+      if (effectId === effectIdRef.current) {
         _pageIndex = null;
       }
       if (pageTreeTimerRef.current) clearTimeout(pageTreeTimerRef.current);
@@ -111,5 +108,5 @@ export function useWorkspaceMeta(workspaceId: string | undefined) {
       provider.destroy();
       doc.destroy();
     };
-  }, [workspaceId, queryClient, thisGen]);
+  }, [workspaceId, queryClient]);
 }

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -38,8 +38,23 @@ function decodePageContent(ydoc: unknown): string {
   return '';
 }
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function extractUuidFromSlug(slug: string): string {
+  const uuidMatch = slug.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+  return uuidMatch?.[1] ?? slug;
+}
+
+function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 export default function Page() {
-  const { pageId, workspaceSlug } = useParams<{ pageId: string; workspaceSlug: string }>();
+  const { slugAndId, workspaceSlug } = useParams<{ slugAndId: string; workspaceSlug: string }>();
+  const pageId = slugAndId ? extractUuidFromSlug(slugAndId) : undefined;
   const navigate = useNavigate();
   const [provider, setProvider] = useState<HocuspocusProvider | null>(null);
   const [collabStatus, setCollabStatus] = useState<WebSocketStatus>(WebSocketStatus.Connecting);
@@ -89,11 +104,33 @@ export default function Page() {
     } else if (existingLink) {
       existingLink.href = '/vite.svg';
     }
-  }, [page]);
+
+    const slug = slugifyTitle(page.title);
+    const canonicalSlug = `${slug}-${page.id}`;
+    let canonicalLink = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+    if (!canonicalLink) {
+      canonicalLink = document.createElement('link');
+      canonicalLink.rel = 'canonical';
+      document.head.appendChild(canonicalLink);
+    }
+    canonicalLink.href = `${window.location.origin}/app/${workspaceSlug}/${canonicalSlug}`;
+  }, [page, workspaceSlug]);
 
   useEffect(() => {
     updateDocumentMeta();
   }, [updateDocumentMeta]);
+
+  useEffect(() => {
+    if (!page || !slugAndId) return;
+
+    const slug = slugifyTitle(page.title);
+    const expectedPath = `${slug}-${page.id}`;
+
+    if (slugAndId !== expectedPath) {
+      const newPath = window.location.pathname.replace(/\/[^/]+$/, `/${expectedPath}`);
+      window.history.replaceState(null, '', newPath);
+    }
+  }, [page, slugAndId]);
 
   const { data: workspaces } = useWorkspaces();
   const workspace = workspaces?.find((item) => item.slug === workspaceSlug);
@@ -177,7 +214,11 @@ export default function Page() {
             <PageIcon pageId={pageId} initialIcon={page?.icon ?? null} />
           </div>
           <div className="pl-[54px] w-full">
-            <PageTitle pageId={pageId} initialTitle={page?.title ?? 'Untitled'} />
+            <PageTitle
+              pageId={pageId}
+              initialTitle={page?.title ?? 'Untitled'}
+              ydoc={provider?.document ?? null}
+            />
           </div>
         </div>
       </div>

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -40,9 +40,10 @@ function decodePageContent(ydoc: unknown): string {
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-function extractUuidFromSlug(slug: string): string {
+function extractUuidFromSlug(slug: string): string | undefined {
   const uuidMatch = slug.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
-  return uuidMatch?.[1] ?? slug;
+  const candidate = uuidMatch?.[1];
+  return candidate && UUID_REGEX.test(candidate) ? candidate : undefined;
 }
 
 function slugifyTitle(title: string): string {


### PR DESCRIPTION
## Summary

Replace the rigid `page_links`, `tags`, and `page_tags` tables with a single unified `connections` table that tracks all page relationships: wikilinks, tags, mentions, embeds, headings, and URLs. Add a `connection_occurrences` table for block-level position tracking.

Key architectural changes:

### Database
- New `connections` table with polymorphic `source_type`/`target_type` + `target_slug` for stable cross-page references
- New `connection_occurrences` table for block-level position tracking
- `pages.title_search` migrated to `tsvector` type with GIN index for full-text search
- `pages.content_search` column added (reserved for future body content search)

### Collab Server
- Complete rewrite: replaces backlink-only extraction with full connection graph rebuild on every page persist
- New workspace meta room (`workspace-meta:{id}`) — a shared Yjs document syncing `pageIndex` (title/icon/parent for sidebar) and `backlinksVersion` (cache invalidation for the frontend)
- `pg_notify` listeners for `page_renamed` and `page_deleted` to keep meta room in sync

### API Routes
- Backlinks, tags, search, and import routes all rewritten to query `connections` instead of deprecated tables
- Pages route now creates Yjs docs with separate `title` text field + `prosemirror` body on creation
- Wiki link UUID resolution on import (`resolveWikilinkTargets`) so backlinks survive page renames
- `pg_notify` on page rename/delete for collab server meta room sync
- Search supports `tags:` filter syntax via connections table

### Web Frontend
- `wikiLinkView` — ProseMirror node view that resolves display titles live from workspace meta room
- `useWorkspaceMeta` hook — connects to collab meta room for page index + backlinks cache invalidation
- Wiki link plugin updated with `targetId` attribute (UUID-based, survives renames)
- Page title now writes to Yjs doc for real-time sync across clients
- Slug-based URL routing (`/app/:workspaceSlug/:slugAndId`) with canonical links
- Collab session token caching to reduce redundant auth calls on reconnection

### Deploy
- Migrated from `drizzle-kit push` to `drizzle-kit migrate` for proper migration-based deploys

## Commits

- `fix(deploy): switch from db:push to db:migrate for migration-based deploys`
- `feat(web): add slug-based URL routing to Page route`
- `feat(web): update backlinks and wiki link suggestion hooks`
- `feat(web): update page title component for Yjs-backed editing`
- `feat(web): add collab token caching and improve Milkdown editor setup`
- `feat(web): update wiki link plugin with targetId resolution`
- `feat(web): add wiki link view component and workspace meta hook`
- `feat(collab): rewrite server with unified connection tracking and workspace meta room`
- `feat(api): add tag filter and GIN index search to search route`
- `feat(api): rewrite tags route for connections table`
- `feat(api): rewrite obsidian import for unified connections and tags`
- `feat(api): update markdown import with Yjs doc resolution`
- `feat(api): add Yjs doc creation and pg_notify to pages route`
- `feat(api): rewrite backlinks route for unified connections`
- `feat(api): update test-utils for connections table`
- `feat(api): add Yjs utility functions for page creation and wiki link resolution`
- `feat(shared): add connection extraction helpers from Yjs`
- `feat(db): add unified connections schema and migrations`