### PR TITLE
fix: heading sync loop, collab hang, and title duplication

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,6 +30,12 @@
     }
   },
   "files": {
-    "ignore": ["**/dist/**", "**/node_modules/**", "**/.turbo/**", "**/coverage/**"]
+    "ignore": [
+      "**/dist/**",
+      "**/node_modules/**",
+      "**/.turbo/**",
+      "**/coverage/**",
+      "**/.sisyphus/**"
+    ]
   }
 }

--- a/packages/collab/src/server.ts
+++ b/packages/collab/src/server.ts
@@ -697,14 +697,27 @@ export function createCollabServer(config: CollabServerConfig) {
         await conn.disconnect();
       }
 
-      // The meta room pageIndex update above is sufficient to keep the
-      // sidebar in sync. We intentionally do NOT modify the active Y.Doc
-      // for this page here. If the rename was initiated from the page editor,
-      // the client already wrote to the Y.Doc via commitTitle -> WebSocket
-      // sync. Modifying it again from pg_notify races with that sync and
-      // causes CRDT merge duplication (e.g., "x" becomes "xx").
-      // If the page is not open, onLoadDocument handles title reconciliation
-      // when it is next opened.
+      // Push the rename to the active Y.Doc so open editors see sidebar/home
+      // renames from other clients. Before pushing, delay briefly to let any
+      // in-flight WebSocket sync from the editing client arrive first — if
+      // it already wrote the new title, we skip to avoid CRDT merging two
+      // identical writes into a duplicate (e.g., "x" becomes "xx").
+      const activeDoc = server.hocuspocus.documents.get(pageId) as Y.Doc | undefined;
+      if (activeDoc) {
+        await new Promise((r) => setTimeout(r, 50));
+        const beforeTitle = activeDoc.getText('title').toString();
+        if (beforeTitle !== newTitle) {
+          activeDoc.transact(() => {
+            const titleText = activeDoc.getText('title');
+            titleText.delete(0, titleText.length);
+            titleText.insert(0, newTitle);
+          });
+          logger.debug(
+            `[listen] pushed rename to active session for page ${pageId}: "${beforeTitle}" -> "${newTitle}"`,
+          );
+        }
+      }
+
       logger.debug(`[listen] updated meta for renamed page ${pageId} -> ${newTitle}`);
     }
 

--- a/packages/collab/src/server.ts
+++ b/packages/collab/src/server.ts
@@ -697,21 +697,14 @@ export function createCollabServer(config: CollabServerConfig) {
         await conn.disconnect();
       }
 
-      const activeDoc = server.hocuspocus.documents.get(pageId) as Y.Doc | undefined;
-      if (activeDoc) {
-        const beforeTitle = activeDoc.getText('title').toString();
-        if (beforeTitle !== newTitle) {
-          activeDoc.transact(() => {
-            const titleText = activeDoc.getText('title');
-            titleText.delete(0, titleText.length);
-            titleText.insert(0, newTitle);
-          });
-          logger.debug(
-            `[listen] pushed rename to active session for page ${pageId}: "${beforeTitle}" -> "${newTitle}"`,
-          );
-        }
-      }
-
+      // The meta room pageIndex update above is sufficient to keep the
+      // sidebar in sync. We intentionally do NOT modify the active Y.Doc
+      // for this page here. If the rename was initiated from the page editor,
+      // the client already wrote to the Y.Doc via commitTitle -> WebSocket
+      // sync. Modifying it again from pg_notify races with that sync and
+      // causes CRDT merge duplication (e.g., "x" becomes "xx").
+      // If the page is not open, onLoadDocument handles title reconciliation
+      // when it is next opened.
       logger.debug(`[listen] updated meta for renamed page ${pageId} -> ${newTitle}`);
     }
 

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -216,16 +216,6 @@ export function MilkdownEditor({
     });
   }, [pageId, doc]);
 
-  // Destroy the Y.Doc and Hocuspocus provider on unmount. Without this,
-  // navigating between pages leaks WebSocket connections and Yjs document
-  // memory. useMemo ensures the references are stable, so this cleanup only
-  // fires on actual unmount (not on React Strict Mode double-renders).
-  useEffect(() => () => {
-    provider.forceSync();
-    provider.destroy();
-    doc.destroy();
-  }, [provider, doc]);
-
   const { setContainer, editor } = useMilkdown({
     ...(initialValue !== undefined && { initialValue }),
     ...(onChange !== undefined && { onChange }),

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -197,7 +197,7 @@ export function MilkdownEditor({
   const cachedTokenRef = useRef<{ token: string; userId: string; expiresAt: number } | null>(null);
 
   const provider = useMemo(() => {
-    const instance = new HocuspocusProvider({
+    return new HocuspocusProvider({
       url: COLLAB_URL,
       name: pageId,
       document: doc,
@@ -214,9 +214,7 @@ export function MilkdownEditor({
         return token;
       },
     });
-
-    return instance;
-  }, [doc, pageId]);
+  }, [pageId, doc]);
 
   const { setContainer, editor } = useMilkdown({
     ...(initialValue !== undefined && { initialValue }),
@@ -642,40 +640,6 @@ export function MilkdownEditor({
   useEffect(() => {
     editorRef.current = editor;
   }, [editor]);
-
-  const isMountedRef = useRef(true);
-  const latestProviderRef = useRef(provider);
-  const latestDocRef = useRef(doc);
-  latestProviderRef.current = provider;
-  latestDocRef.current = doc;
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const capturedProvider = provider;
-    const capturedDoc = doc;
-
-    return () => {
-      if (latestProviderRef.current !== capturedProvider || latestDocRef.current !== capturedDoc) {
-        capturedProvider.forceSync();
-        capturedProvider.destroy();
-        capturedDoc.destroy();
-        return;
-      }
-      setTimeout(() => {
-        if (!isMountedRef.current) {
-          capturedProvider.forceSync();
-          capturedProvider.destroy();
-          capturedDoc.destroy();
-        }
-      }, 0);
-    };
-  }, [provider, doc]);
 
   useEffect(() => {
     if (!editor) return;

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -216,6 +216,16 @@ export function MilkdownEditor({
     });
   }, [pageId, doc]);
 
+  // Destroy the Y.Doc and Hocuspocus provider on unmount. Without this,
+  // navigating between pages leaks WebSocket connections and Yjs document
+  // memory. useMemo ensures the references are stable, so this cleanup only
+  // fires on actual unmount (not on React Strict Mode double-renders).
+  useEffect(() => () => {
+    provider.forceSync();
+    provider.destroy();
+    doc.destroy();
+  }, [provider, doc]);
+
   const { setContainer, editor } = useMilkdown({
     ...(initialValue !== undefined && { initialValue }),
     ...(onChange !== undefined && { onChange }),

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -227,6 +227,49 @@ export function MilkdownEditor({
 
   useAwareness(provider);
 
+  // Cleanup: destroy provider and Y.Doc on unmount. The ref-capture
+  // pattern distinguishes Strict Mode double-fire from real unmount:
+  // when latest refs differ from captured, we know the instances were
+  // replaced (Strict Mode re-render) and we destroy the old ones
+  // immediately. When refs match, we wait for isMountedRef to flip
+  // false (real unmount) via setTimeout.
+  // The status listener effect below is declared AFTER this one, so
+  // React cleans it up FIRST (bottom-to-top), removing the listener
+  // before provider.destroy() fires its disconnected event.
+  const isMountedRef = useRef(true);
+  const latestProviderRef = useRef(provider);
+  const latestDocRef = useRef(doc);
+  latestProviderRef.current = provider;
+  latestDocRef.current = doc;
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const capturedProvider = provider;
+    const capturedDoc = doc;
+
+    return () => {
+      if (latestProviderRef.current !== capturedProvider || latestDocRef.current !== capturedDoc) {
+        capturedProvider.forceSync();
+        capturedProvider.destroy();
+        capturedDoc.destroy();
+        return;
+      }
+      setTimeout(() => {
+        if (!isMountedRef.current) {
+          capturedProvider.forceSync();
+          capturedProvider.destroy();
+          capturedDoc.destroy();
+        }
+      }, 0);
+    };
+  }, [provider, doc]);
+
   const { visible, position, keepVisible } = useFloatingToolbar();
 
   const runMarkCommand = (markName: string, attrs?: Record<string, unknown>) => {

--- a/packages/web/src/components/editor/TableOfContents.tsx
+++ b/packages/web/src/components/editor/TableOfContents.tsx
@@ -36,6 +36,10 @@ export function TableOfContents({ editorElement }: TableOfContentsProps) {
         let id = el.id;
 
         if (!id) {
+          // The heading schema's toDOM already generates DOM ids at render
+          // time (id: node.attrs.id || getId(node)), so we don't need to
+          // mutate the DOM here. Setting el.id would trigger this component's
+          // own MutationObserver, causing a re-render cascade.
           id = text
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, '-')

--- a/packages/web/src/components/editor/TableOfContents.tsx
+++ b/packages/web/src/components/editor/TableOfContents.tsx
@@ -40,7 +40,6 @@ export function TableOfContents({ editorElement }: TableOfContentsProps) {
             .toLowerCase()
             .replace(/[^a-z0-9]+/g, '-')
             .replace(/^-|-$/g, '');
-          el.id = id;
         }
 
         const node: HeadingNode = { id, text, level, children: [] };
@@ -123,7 +122,7 @@ export function TableOfContents({ editorElement }: TableOfContentsProps) {
 
   const scrollToHeading = (headingId: string) => {
     if (!editorElement) return;
-    const element = editorElement.querySelector(`#${headingId}`);
+    const element = editorElement.querySelector(`#${CSS.escape(headingId)}`);
     if (element) {
       element.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -223,7 +222,7 @@ export function TableOfContents({ editorElement }: TableOfContentsProps) {
           isHovered ? 'opacity-0 translate-x-2 pointer-events-none' : 'opacity-100 translate-x-0',
         )}
       >
-        <div className="flex flex-col gap-0.5 max-h-[60vh] overflow-y-auto scrollbar-hide">
+        <div className="flex flex-col gap-0.5 max-h-[60vh] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {renderTickMarks()}
         </div>
       </div>

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -612,6 +612,13 @@ export function useMilkdown({
       }
 
       if (shouldUseCollab && doc) {
+        // syncHeadingIdPlugin dispatches setNodeMarkup transactions on every
+        // doc update to assign heading IDs. y-prosemirror's ySyncPlugin then
+        // syncs those mutations to the Y.Doc, which triggers observeDeep,
+        // which re-renders ProseMirror, which fires syncHeadingIdPlugin again.
+        // Milkdown's own vanilla-collab example removes this plugin in collab
+        // mode. We also defer connect via setTimeout(0) so Milkdown processes
+        // the plugin removal before ySyncPlugin is injected.
         runtimeEditor.remove(syncHeadingIdPlugin);
         setTimeout(() => {
           if (disposed || !runtimeEditor) return;

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -7,7 +7,7 @@ import {
 } from '@milkdown/core';
 import { collab, collabServiceCtx } from '@milkdown/plugin-collab';
 import { listener, listenerCtx } from '@milkdown/plugin-listener';
-import { commonmark } from '@milkdown/preset-commonmark';
+import { commonmark, syncHeadingIdPlugin } from '@milkdown/preset-commonmark';
 import { gfm } from '@milkdown/preset-gfm';
 import { getMarkdown, insert, replaceAll } from '@milkdown/utils';
 import Papa from 'papaparse';
@@ -611,16 +611,22 @@ export function useMilkdown({
         return;
       }
 
-      if (shouldUseCollab && doc && provider) {
-        runtimeEditor.action((ctx) => {
-          const collabService = ctx.get(collabServiceCtx);
-          collabService.bindDoc(doc);
-          const awareness = provider.awareness;
-          if (awareness) {
-            collabService.setAwareness(awareness);
-          }
-          collabService.connect();
-        });
+      if (shouldUseCollab && doc) {
+        runtimeEditor.remove(syncHeadingIdPlugin);
+        setTimeout(() => {
+          if (disposed || !runtimeEditor) return;
+          runtimeEditor.action((ctx) => {
+            const collabService = ctx.get(collabServiceCtx);
+            collabService.bindDoc(doc);
+            if (provider) {
+              const awareness = provider.awareness;
+              if (awareness) {
+                collabService.setAwareness(awareness);
+              }
+              collabService.connect();
+            }
+          });
+        }, 0);
       }
 
       editorRef.current = runtimeEditor;

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -57,6 +57,14 @@ export default function Page() {
   const navigate = useNavigate();
   const [provider, setProvider] = useState<HocuspocusProvider | null>(null);
   const [collabStatus, setCollabStatus] = useState<WebSocketStatus>(WebSocketStatus.Connecting);
+
+  // Clear state on page navigation.
+  useEffect(() => {
+    setProvider(null);
+    setCollabStatus(WebSocketStatus.Connecting);
+    setEditorElement(null);
+    void pageId;
+  }, [pageId]);
   const [editorElement, setEditorElement] = useState<HTMLElement | null>(null);
 
   const { data: page } = useQuery({

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -68,6 +68,11 @@ export default function Page() {
     enabled: !!pageId,
   });
 
+  // Find the .milkdown-editor DOM element and pass it to TableOfContents.
+  // Re-runs on page navigation (MilkdownEditor is keyed by pageId, so the
+  // old editor unmounts and a new one mounts). Safe to use [page] deps now
+  // that TableOfContents no longer mutates heading DOM ids (which caused a
+  // MutationObserver cascade with useState-triggered re-renders).
   useEffect(() => {
     const el = document.querySelector('.milkdown-editor') as HTMLElement | null;
     if (el) setEditorElement(el);
@@ -76,7 +81,7 @@ export default function Page() {
       if (el2) setEditorElement(el2);
     }, 500);
     return () => clearTimeout(id);
-  }, []);
+  }, [page]);
 
   const handleStatusChange = (newStatus: WebSocketStatus) => {
     setCollabStatus(newStatus);

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -2,7 +2,7 @@ import type { HocuspocusProvider } from '@hocuspocus/provider';
 import { WebSocketStatus } from '@hocuspocus/provider';
 import type { Folder, FolderTreeNode, PageTreeNode, Page as PageType } from '@markdawn/shared';
 import { useQuery } from '@tanstack/react-query';
-import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { BacklinksPanel } from '../components/editor/BacklinksPanel';
 import { Breadcrumbs } from '../components/editor/Breadcrumbs';
@@ -28,9 +28,7 @@ async function fetchPage(pageId: string): Promise<PageType> {
 }
 
 function decodePageContent(ydoc: unknown): string {
-  if (!ydoc || !Array.isArray(ydoc) || ydoc.length === 0) {
-    return '';
-  }
+  if (!ydoc || !Array.isArray(ydoc) || ydoc.length === 0) return '';
   const hasNullByte = ydoc.includes(0);
   if (!hasNullByte) {
     return new TextDecoder().decode(new Uint8Array(ydoc as number[]));
@@ -59,25 +57,7 @@ export default function Page() {
   const navigate = useNavigate();
   const [provider, setProvider] = useState<HocuspocusProvider | null>(null);
   const [collabStatus, setCollabStatus] = useState<WebSocketStatus>(WebSocketStatus.Connecting);
-  const editorElementRef = useRef<HTMLElement | null>(null);
-
-  const handleStatusChange = (newStatus: WebSocketStatus) => {
-    setCollabStatus(newStatus);
-  };
-
-  useEffect(() => {
-    const findEditorElement = () => {
-      const editorElement = document.querySelector('.milkdown-editor');
-      if (editorElement) {
-        editorElementRef.current = editorElement as HTMLElement;
-      }
-    };
-
-    findEditorElement();
-    const timeoutId = setTimeout(findEditorElement, 500);
-
-    return () => clearTimeout(timeoutId);
-  }, []);
+  const [editorElement, setEditorElement] = useState<HTMLElement | null>(null);
 
   const { data: page } = useQuery({
     queryKey: ['pages', 'detail', pageId],
@@ -87,6 +67,20 @@ export default function Page() {
     },
     enabled: !!pageId,
   });
+
+  useEffect(() => {
+    const el = document.querySelector('.milkdown-editor') as HTMLElement | null;
+    if (el) setEditorElement(el);
+    const id = setTimeout(() => {
+      const el2 = document.querySelector('.milkdown-editor') as HTMLElement | null;
+      if (el2) setEditorElement(el2);
+    }, 500);
+    return () => clearTimeout(id);
+  }, []);
+
+  const handleStatusChange = (newStatus: WebSocketStatus) => {
+    setCollabStatus(newStatus);
+  };
 
   const updateDocumentMeta = useCallback(() => {
     if (!page) return;
@@ -224,17 +218,19 @@ export default function Page() {
         </div>
       </div>
       <PropertiesPanel pageId={pageId} properties={page?.properties ?? null} />
-      <MilkdownEditor
-        key={pageId}
-        pageId={pageId}
-        workspaceId={workspaceId ?? ''}
-        initialValue={decodePageContent(page?.ydoc)}
-        onProviderReady={setProvider}
-        onStatusChange={handleStatusChange}
-        onWikiLinkClick={handleWikiLinkClick}
-      />
+      {page ? (
+        <MilkdownEditor
+          key={pageId}
+          pageId={pageId}
+          workspaceId={workspaceId ?? ''}
+          initialValue={decodePageContent(page.ydoc)}
+          onProviderReady={setProvider}
+          onStatusChange={handleStatusChange}
+          onWikiLinkClick={handleWikiLinkClick}
+        />
+      ) : null}
       <BacklinksPanel pageId={pageId} workspaceSlug={workspaceSlug} />
-      <TableOfContents editorElement={editorElementRef.current} />
+      <TableOfContents editorElement={editorElement} />
     </div>
   );
 }

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -68,22 +68,31 @@ export default function Page() {
     enabled: !!pageId,
   });
 
-  // Find the .milkdown-editor DOM element and pass it to TableOfContents.
-  // Re-runs on page navigation (MilkdownEditor is keyed by pageId, so the
-  // old editor unmounts and a new one mounts). Safe to use [page] deps now
-  // that TableOfContents no longer mutates heading DOM ids (which caused a
-  // Find the editor DOM element for TableOfContents. Runs once on mount;
-  // TOC re-queries the DOM internally via MutationObserver so stale refs
-  // after page navigation are harmless.
+  // Find the .milkdown-editor DOM element for TableOfContents.
+  // Re-runs on page change (data load or navigation) to handle the
+  // editor mounting asynchronously after page fetch completes.
+  // Polls up to 4 times (0ms, 200ms, 600ms, 1400ms) to catch the
+  // editor regardless of page load timing.
   useEffect(() => {
-    const el = document.querySelector('.milkdown-editor') as HTMLElement | null;
-    if (el) setEditorElement(el);
-    const id = setTimeout(() => {
-      const el2 = document.querySelector('.milkdown-editor') as HTMLElement | null;
-      if (el2) setEditorElement(el2);
-    }, 500);
+    if (!page) return;
+    let attempts = 0;
+    const maxAttempts = 4;
+    let id: ReturnType<typeof setTimeout>;
+
+    const poll = () => {
+      const el = document.querySelector('.milkdown-editor') as HTMLElement | null;
+      if (el) {
+        setEditorElement(el);
+        return;
+      }
+      attempts++;
+      if (attempts < maxAttempts) {
+        id = setTimeout(poll, attempts * 200);
+      }
+    };
+    poll();
     return () => clearTimeout(id);
-  }, []);
+  }, [page]);
 
   const handleStatusChange = (newStatus: WebSocketStatus) => {
     setCollabStatus(newStatus);

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -72,7 +72,9 @@ export default function Page() {
   // Re-runs on page navigation (MilkdownEditor is keyed by pageId, so the
   // old editor unmounts and a new one mounts). Safe to use [page] deps now
   // that TableOfContents no longer mutates heading DOM ids (which caused a
-  // MutationObserver cascade with useState-triggered re-renders).
+  // Find the editor DOM element for TableOfContents. Runs once on mount;
+  // TOC re-queries the DOM internally via MutationObserver so stale refs
+  // after page navigation are harmless.
   useEffect(() => {
     const el = document.querySelector('.milkdown-editor') as HTMLElement | null;
     if (el) setEditorElement(el);
@@ -81,7 +83,7 @@ export default function Page() {
       if (el2) setEditorElement(el2);
     }, 500);
     return () => clearTimeout(id);
-  }, [page]);
+  }, []);
 
   const handleStatusChange = (newStatus: WebSocketStatus) => {
     setCollabStatus(newStatus);


### PR DESCRIPTION
## Summary

Fixes three critical bugs in collaborative editing:

1. **Page completely hangs on open** — caused by `hasCollab` set to `Boolean(doc)` instead of `Boolean(doc && provider)`, loading y-prosemirror plugins before the WebSocket provider was ready.

2. **Heading input rule (`# `) causes infinite sync loop** — `syncHeadingIdPlugin` dispatches `setNodeMarkup` transactions on every doc update, which `ySyncPlugin` syncs to the Y.Doc, triggering `observeDeep`, which re-renders ProseMirror, which fires `syncHeadingIdPlugin` again. Fixed by removing `syncHeadingIdPlugin` when collab is active (matching Milkdown's own vanilla-collab example).

3. **Title duplication when renaming via page editor** — `commitTitle` writes to both Y.Doc (WebSocket sync) and PATCH API (SQL → pg_notify → `handlePageRenamed`). The pg_notify handler then writes to the same Y.Doc via `activeDoc.transact()`. If pg_notify beats the WebSocket, both writes merge as CRDT duplicates.

## Changes

- Revert `hasCollab` to `Boolean(doc && provider)` and restore `provider` to synchronous `useMemo`
- Remove `syncHeadingIdPlugin` with `setTimeout(0)` deferral before `collabService.connect()`
- Remove `activeDoc` update from `handlePageRenamed` in collab server
- Prevent TOC `MutationObserver` cascade by removing DOM mutation (`el.id = id`)
- Stable editor element binding for `TableOfContents`
- Documentation comments at each non-obvious decision point