### PR TITLE
feat(editor): slash menu with block command insertion

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -89,7 +89,7 @@ podman exec -i markdawn-postgres-dev psql -U markdawn -d markdawn <<'SQL'
 BEGIN;
 DELETE FROM sessions WHERE user_id IN (SELECT owner_id FROM workspaces WHERE slug = 'e2e-test-workspace');
 DELETE FROM workspace_members WHERE workspace_id IN (SELECT id FROM workspaces WHERE slug = 'e2e-test-workspace');
-DELETE FROM workspaces WHERE slug = 'e2e-test-workspace');
+DELETE FROM workspaces WHERE slug = 'e2e-test-workspace';
 DELETE FROM users WHERE id NOT IN (SELECT owner_id FROM workspaces);
 COMMIT;
 SQL

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,0 +1,163 @@
+# AGENTS.md — E2E Tests (Playwright)
+
+## Running Tests
+
+**Always run from the `e2e/` directory, not the project root:**
+
+```bash
+cd e2e
+npx playwright test                         # all tests
+npx playwright test editor/slash-menu.spec.ts  # single file
+```
+
+The config at `e2e/playwright.config.ts` uses relative paths (`./playwright/.auth/user.json`) that resolve correctly only when CWD is `e2e/`.
+
+## Prerequisites
+
+### 1. PostgreSQL
+
+A PostgreSQL container must be running on `localhost:5432` with:
+- User: `markdawn`
+- Password: `password`
+- Database: `markdawn`
+
+The dev container is named `markdawn-postgres-dev`. Start it:
+
+```bash
+# From project root
+pnpm db:start
+```
+
+### 2. Database Schema
+
+Push the schema if not already applied:
+
+```bash
+cd packages/api
+DATABASE_URL=postgresql://markdawn:password@localhost:5432/markdawn pnpm exec drizzle-kit push --force
+```
+
+### 3. Dev Servers
+
+Both API (port 3001) and Vite dev server (port 5173) must be running:
+
+```bash
+# From project root — this starts API, collab, and web in parallel
+pnpm dev
+```
+
+The `.env` file at the project root is loaded automatically by `packages/api/src/env.ts`. Required env vars:
+
+| Variable | Example |
+|---|---|
+| `DATABASE_URL` | `postgresql://markdawn:password@localhost:5432/markdawn` |
+| `BETTER_AUTH_SECRET` | (at least 32 chars) |
+| `FRONTEND_URL` | `http://localhost:5173` |
+| `PORT` | `3001` |
+| `NODE_ENV` | `development` |
+
+`TEST_SETUP_TOKEN` is optional — if absent, the token check is skipped.
+
+### 4. Playwright Browsers
+
+```bash
+cd e2e
+npx playwright install chromium firefox
+```
+
+## Auth Setup Gotchas
+
+### How Auth Works
+
+The setup test (`auth.setup.ts`) calls `POST /api/test/setup` which:
+1. Creates a test user + personal workspace in the database
+2. Updates the workspace slug to `e2e-test-workspace`
+3. Creates a signed session cookie
+4. Navigates to `/app/e2e-test-workspace/`
+5. Saves browser storage state to `e2e/playwright/.auth/user.json`
+
+Subsequent tests load this storage state to be authenticated.
+
+### Stale Test Data
+
+**This is the most common failure.** The test setup endpoint always sets the workspace slug to `e2e-test-workspace`, which is a fixed value. If a previous test run left this slug in the database, new setup requests will fail with a `unique constraint violation` on `workspaces_slug_unique`.
+
+**Fix** — clean stale test data from the dev database:
+
+```bash
+podman exec -i markdawn-postgres-dev psql -U markdawn -d markdawn <<'SQL'
+BEGIN;
+DELETE FROM sessions WHERE user_id IN (SELECT owner_id FROM workspaces WHERE slug = 'e2e-test-workspace');
+DELETE FROM workspace_members WHERE workspace_id IN (SELECT id FROM workspaces WHERE slug = 'e2e-test-workspace');
+DELETE FROM workspaces WHERE slug = 'e2e-test-workspace');
+DELETE FROM users WHERE id NOT IN (SELECT owner_id FROM workspaces);
+COMMIT;
+SQL
+```
+
+Then delete the cached auth state:
+
+```bash
+rm -f e2e/playwright/.auth/user.json
+```
+
+### Auth File Path
+
+The auth setup writes to `e2e/playwright/.auth/user.json` (using `__dirname`). The config reads from `./playwright/.auth/user.json`. Both resolve to the same absolute path as long as CWD is `e2e/`.
+
+If you see `ENOENT: no such file or directory, open './playwright/.auth/user.json'`, you're likely running from the wrong directory.
+
+## CI vs Local Differences
+
+| Aspect | CI | Local |
+|---|---|---|
+| PostgreSQL container | `markdawn-postgres-e2e` (fresh each run) | `markdawn-postgres-dev` (persistent) |
+| Database state | Empty — schema pushed fresh | Has leftover test data |
+| Working directory | `e2e/` | Must be `e2e/` |
+| TEST_SETUP_TOKEN | Set to `e2e-test-setup-secret` | Not needed (check skipped) |
+
+## Writing Tests
+
+### Patterns
+
+All existing E2E tests follow this pattern:
+
+```typescript
+import { expect, test } from '@playwright/test';
+import { createNewPage, focusEditor } from '../fixtures';
+
+test('my test', async ({ page }) => {
+  await createNewPage(page);   // navigates to app, creates a new page
+  await focusEditor(page);     // clicks on ProseMirror editor
+  // ...interact with editor...
+  await expect(page.locator('.ProseMirror h1')).toBeVisible();
+});
+```
+
+### Selectors
+
+- Editor content: `.ProseMirror`
+- Slash menu: `[data-testid="slash-menu"]`
+- Wiki link suggestions: `[data-testid="wikilink-suggestions"]`
+- Floating toolbar buttons: `.floating-toolbar button[title="..."]`
+- Page title input: `input[data-testid="page-title"]`
+- Headings: `.ProseMirror h1`, `.ProseMirror h2`, etc.
+- Bold: `.ProseMirror strong`
+- Italic: `.ProseMirror em`
+- Blockquote: `.ProseMirror blockquote`
+- Bullet list: `.ProseMirror ul`
+- Ordered list: `.ProseMirror ol`
+- Task list: `.ProseMirror li[data-item-type="task"]`
+- Table: `.ProseMirror table`
+- Divider: `.ProseMirror hr`
+
+### Slash Menu Specifics
+
+- The slash menu renders as a fixed-position popup with `data-testid="slash-menu"`
+- Commands are `<button>` elements inside the menu container
+- The first visible item (index 0) is "Paragraph" when no filter is active
+- Fuse.js fuzzy search with threshold 0.35 is used for filtering
+- Keyboard: ArrowDown/ArrowUp cycle through items; Enter selects; Escape closes
+- Click-outside also closes the menu
+- After selecting a command, the `/query` text is removed from the editor
+- The menu container shows "No matching commands" when the query matches nothing

--- a/e2e/editor/slash-menu.spec.ts
+++ b/e2e/editor/slash-menu.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+import { createNewPage, focusEditor } from '../fixtures';
+
+test.describe('Slash menu', () => {
+  test('can search and insert heading blocks', async ({ page }) => {
+    await createNewPage(page);
+    await focusEditor(page);
+
+    await page.keyboard.type('/h2');
+    await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Heading from slash');
+
+    await expect(page.locator('.ProseMirror h2')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror h2')).toHaveText('Heading from slash');
+  });
+
+  test('can insert checklist items from slash command', async ({ page }) => {
+    await createNewPage(page);
+    await focusEditor(page);
+
+    await page.keyboard.type('/check');
+    await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+    await page.keyboard.press('Enter');
+    await page.keyboard.type('Task from slash');
+
+    await expect(page.locator('.ProseMirror li[data-item-type="task"]')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.locator('.ProseMirror li[data-item-type="task"]')).toContainText(
+      'Task from slash',
+    );
+  });
+});

--- a/e2e/editor/slash-menu.spec.ts
+++ b/e2e/editor/slash-menu.spec.ts
@@ -2,33 +2,259 @@ import { expect, test } from '@playwright/test';
 import { createNewPage, focusEditor } from '../fixtures';
 
 test.describe('Slash menu', () => {
-  test('can search and insert heading blocks', async ({ page }) => {
-    await createNewPage(page);
-    await focusEditor(page);
+  test.describe('Trigger and visibility', () => {
+    test('opens when / is typed at line start', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      const menu = page.locator('[data-testid="slash-menu"]');
+      await expect(menu).toBeVisible({ timeout: 5000 });
+    });
 
-    await page.keyboard.type('/h2');
-    await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('Heading from slash');
+    test('does not open when / is typed mid-word', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('abc/');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+    });
 
-    await expect(page.locator('.ProseMirror h2')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('.ProseMirror h2')).toHaveText('Heading from slash');
+    test('shows all commands with empty query (just /)', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      const menu = page.locator('[data-testid="slash-menu"]');
+      await expect(menu).toBeVisible({ timeout: 5000 });
+      const buttons = page.locator('[data-testid="slash-menu"] button');
+      await expect(buttons.first()).toBeVisible();
+      const count = await buttons.count();
+      expect(count).toBeGreaterThan(10);
+    });
   });
 
-  test('can insert checklist items from slash command', async ({ page }) => {
-    await createNewPage(page);
-    await focusEditor(page);
+  test.describe('Search and filtering', () => {
+    test('filters commands by fuzzy search', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
 
-    await page.keyboard.type('/check');
-    await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
-    await page.keyboard.press('Enter');
-    await page.keyboard.type('Task from slash');
-
-    await expect(page.locator('.ProseMirror li[data-item-type="task"]')).toBeVisible({
-      timeout: 5000,
+      await page.keyboard.type('table');
+      await expect(page.locator('[data-testid="slash-menu"]')).toContainText('Table');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toContainText(
+        'No matching commands',
+      );
     });
-    await expect(page.locator('.ProseMirror li[data-item-type="task"]')).toContainText(
-      'Task from slash',
-    );
+
+    test('shows no-match message for gibberish query', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/zzzzz');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('[data-testid="slash-menu"]')).toContainText(
+        'No matching commands',
+      );
+    });
+  });
+
+  test.describe('Dismissal', () => {
+    test('closes on Escape key', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Escape');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('closes on click outside the menu', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.locator('input[data-testid="page-title"]').click({ timeout: 5000 });
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+  });
+
+  test.describe('Keyboard navigation', () => {
+    test('ArrowDown cycles selection and Enter executes the selected command', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Keyboard Heading');
+      await expect(page.locator('.ProseMirror h1')).toContainText('Keyboard Heading', {
+        timeout: 5000,
+      });
+    });
+  });
+
+  test.describe('Trigger cleanup', () => {
+    test('removes the /query text after a command is selected', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/h2');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Clean Text');
+      await expect(page.locator('.ProseMirror h2')).toContainText('Clean Text', { timeout: 5000 });
+      await expect(page.locator('.ProseMirror')).not.toContainText('/h2');
+    });
+  });
+
+  test.describe('Block commands', () => {
+    test('inserts heading 1 via /h1', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/h1');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Main Title');
+      await expect(page.locator('.ProseMirror h1')).toContainText('Main Title', { timeout: 5000 });
+    });
+
+    test('inserts blockquote via /blockquote', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/blockquote');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Cited text');
+      await expect(page.locator('.ProseMirror blockquote')).toContainText('Cited text', {
+        timeout: 5000,
+      });
+    });
+
+    test('inserts bullet list via /bullet', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/bullet');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('List item');
+      await expect(page.locator('.ProseMirror ul')).toContainText('List item', { timeout: 5000 });
+    });
+
+    test('inserts ordered list via /ordered', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/ordered');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('First item');
+      await expect(page.locator('.ProseMirror ol')).toContainText('First item', { timeout: 5000 });
+    });
+
+    test('inserts task list via /check', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/check');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Task item');
+      await expect(page.locator('.ProseMirror li[data-item-type="task"]')).toContainText(
+        'Task item',
+        { timeout: 5000 },
+      );
+    });
+
+    test('inserts table via /table', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/table');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await expect(page.locator('.ProseMirror table')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('inserts horizontal divider via /divider', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/divider');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await expect(page.locator('.ProseMirror hr')).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe('Inline mark commands', () => {
+    test('bold command applies bold to subsequent typing', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/bold');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+      await page.keyboard.type('bold text');
+      await expect(page.locator('.ProseMirror strong')).toContainText('bold text', {
+        timeout: 5000,
+      });
+    });
+
+    test('italic command applies italic to subsequent typing', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/italic');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+      await page.keyboard.type('italic text');
+      await expect(page.locator('.ProseMirror em')).toContainText('italic text', {
+        timeout: 5000,
+      });
+    });
+  });
+
+  test.describe('Sequential use', () => {
+    test('can execute multiple slash commands one after another', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+
+      await page.keyboard.type('/h1');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('First Section');
+      await expect(page.locator('.ProseMirror h1')).toContainText('First Section', {
+        timeout: 5000,
+      });
+
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/h2');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Second Section');
+      await expect(page.locator('.ProseMirror h2')).toContainText('Second Section', {
+        timeout: 5000,
+      });
+
+      await expect(page.locator('.ProseMirror h1')).toHaveCount(1);
+      await expect(page.locator('.ProseMirror h2')).toHaveCount(1);
+    });
+  });
+
+  test.describe('Regression', () => {
+    test('wiki link [[ still triggers suggestions alongside slash menu', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+
+      await page.keyboard.type('[[');
+      const popup = page.getByTestId('wikilink-suggestions');
+      await expect(popup).toBeVisible({ timeout: 5000 });
+
+      await page.keyboard.press('Escape');
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/h2');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Heading from slash');
+      await expect(page.locator('.ProseMirror h2')).toContainText('Heading from slash', {
+        timeout: 5000,
+      });
+    });
   });
 });

--- a/e2e/editor/toolbar.spec.ts
+++ b/e2e/editor/toolbar.spec.ts
@@ -36,7 +36,7 @@ test.describe('Floating toolbar buttons', () => {
     // Inline code
     await page.keyboard.type('code');
     await page.keyboard.press('Control+a');
-    await page.locator('.floating-toolbar button[title="Inline Code"]').click({ timeout: 5000 });
+    await page.locator('.floating-toolbar button[title="Code"]').click({ timeout: 5000 });
     await expect(page.locator('.ProseMirror code')).toBeVisible();
   });
 

--- a/packages/web/src/components/editor/FloatingToolbar.tsx
+++ b/packages/web/src/components/editor/FloatingToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  IconBlockquote,
   IconBold,
   IconCode,
   IconColumnInsertLeft,
@@ -32,6 +33,7 @@ export interface FloatingToolbarProps {
   onStrike: () => void;
   onCode: () => void;
   onLink: () => void;
+  onBlockquote: () => void;
   onImageUpload: (file: File) => void;
   onInsertTable: () => void;
   onAddRowBefore: () => void;
@@ -57,6 +59,7 @@ export interface FloatingToolbarProps {
   isStrikeActive?: boolean;
   isCodeActive?: boolean;
   isLinkActive?: boolean;
+  isBlockquoteActive?: boolean;
   isH1Active?: boolean;
   isH2Active?: boolean;
   isH3Active?: boolean;
@@ -75,6 +78,7 @@ export function FloatingToolbar({
   onStrike,
   onCode,
   onLink,
+  onBlockquote,
   onImageUpload,
   onInsertTable,
   onAddRowBefore,
@@ -100,6 +104,7 @@ export function FloatingToolbar({
   isStrikeActive,
   isCodeActive,
   isLinkActive,
+  isBlockquoteActive,
   isH1Active,
   isH2Active,
   isH3Active,
@@ -166,11 +171,10 @@ export function FloatingToolbar({
         type="button"
         onClick={onCode}
         className={`floating-toolbar-btn p-1.5 rounded hover:bg-zinc-700 text-zinc-300 transition-colors cursor-pointer ${isCodeActive ? 'bg-zinc-600 text-white' : ''}`}
-        title="Inline Code"
+        title="Code"
       >
         <IconCode size={16} />
       </button>
-      <div className="w-px h-5 bg-zinc-600 mx-1" />
       <button
         type="button"
         onClick={onLink}
@@ -178,6 +182,14 @@ export function FloatingToolbar({
         title="Add Link"
       >
         <IconLink size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={onBlockquote}
+        className={`floating-toolbar-btn p-1.5 rounded hover:bg-zinc-700 text-zinc-300 transition-colors cursor-pointer ${isBlockquoteActive ? 'bg-zinc-600 text-white' : ''}`}
+        title="Blockquote"
+      >
+        <IconBlockquote size={16} />
       </button>
       <div className="w-px h-5 bg-zinc-600 mx-1" />
       <button

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -561,10 +561,7 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const { $from } = state.selection;
-      const codeType = state.schema.marks.code;
-      if (!codeType) return;
-
-      const tr = state.tr.insertText('#tag', $from.pos);
+      const tr = state.tr.insertText('#tag ', $from.pos);
       dispatch(tr);
     });
   };
@@ -827,14 +824,7 @@ export function MilkdownEditor({
       const blockquoteType = state.schema.nodes.blockquote;
       if (!blockquoteType) return;
 
-      const { $from } = state.selection;
-      let inBlockquote = false;
-
-      state.doc.nodesBetween($from.pos, $from.pos, (node) => {
-        if (node.type === blockquoteType) {
-          inBlockquote = true;
-        }
-      });
+      const inBlockquote = hasParentBlockType(state, blockquoteType);
 
       if (inBlockquote) {
         const command = lift;

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -1,3 +1,22 @@
+import {
+  IconBlockquote,
+  IconBold,
+  IconCode,
+  IconH1,
+  IconH2,
+  IconH3,
+  IconH4,
+  IconH5,
+  IconH6,
+  IconItalic,
+  IconLink,
+  IconList,
+  IconListCheck,
+  IconListNumbers,
+  IconPhoto,
+  IconStrikethrough,
+  IconTable,
+} from '@tabler/icons-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAwareness } from '../../hooks/useAwareness';
 import { useFloatingToolbar } from '../../hooks/useFloatingToolbar';
@@ -12,9 +31,10 @@ import { commandsCtx, editorViewCtx } from '@milkdown/core';
 import type { Editor } from '@milkdown/core';
 import type { EditorView } from '@milkdown/kit/prose/view';
 import { insertTableCommand } from '@milkdown/preset-gfm';
-import { setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
+import { lift, setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
 import type { MarkType, NodeType } from 'prosemirror-model';
 import type { EditorState } from 'prosemirror-state';
+import { TextSelection } from 'prosemirror-state';
 import {
   addColumnAfter,
   addColumnBefore,
@@ -27,6 +47,7 @@ import {
 } from 'prosemirror-tables';
 import * as Y from 'yjs';
 import { FloatingToolbar } from './FloatingToolbar';
+import { SlashMenu } from './SlashMenu';
 import { WikiLinkSuggestions } from './WikiLinkSuggestions';
 
 interface MilkdownEditorProps {
@@ -71,12 +92,36 @@ export function MilkdownEditor({
     closeSuggestions,
   } = useWikiLinkSuggestions(workspaceId, editorRef);
 
+  const [slashMenuState, setSlashMenuState] = useState({
+    isOpen: false,
+    query: '',
+    position: null as { x: number; y: number; top?: number; bottom?: number } | null,
+    range: null as { from: number; to: number } | null,
+  });
+
+  const handleSlashMenuSuggest = useCallback(
+    (
+      isOpen: boolean,
+      query: string,
+      position: { x: number; y: number; top?: number; bottom?: number } | null,
+      range: { from: number; to: number } | null,
+    ) => {
+      setSlashMenuState({ isOpen, query, position, range });
+    },
+    [],
+  );
+
+  const closeSlashMenu = useCallback(() => {
+    setSlashMenuState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
   const [activeStates, setActiveStates] = useState({
     isBoldActive: false,
     isItalicActive: false,
     isStrikeActive: false,
     isCodeActive: false,
     isLinkActive: false,
+    isBlockquoteActive: false,
     isH1Active: false,
     isH2Active: false,
     isH3Active: false,
@@ -174,6 +219,7 @@ export function MilkdownEditor({
           isStrikeActive: hasMark(state, marks.strike_through),
           isCodeActive: hasMark(state, marks.inlineCode) || hasBlockType(state, nodes.code_block),
           isLinkActive: hasMark(state, marks.link),
+          isBlockquoteActive: hasParentBlockType(state, nodes.blockquote),
           isH1Active: hasBlockType(state, nodes.heading, { level: 1 }),
           isH2Active: hasBlockType(state, nodes.heading, { level: 2 }),
           isH3Active: hasBlockType(state, nodes.heading, { level: 3 }),
@@ -223,6 +269,7 @@ export function MilkdownEditor({
     provider,
     onWikiLinkClick,
     onWikiLinkSuggest: handleWikiLinkSuggest,
+    onSlashMenuSuggest: handleSlashMenuSuggest,
   });
 
   useAwareness(provider);
@@ -391,6 +438,349 @@ export function MilkdownEditor({
     });
   };
 
+  // Slash-specific handlers that don't call keepVisible()
+  const handleSlashParagraph = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const paraType = state.schema.nodes.paragraph;
+      if (!paraType) return;
+      const command = setBlockType(paraType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashHeading = (level: number) => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const headingType = state.schema.nodes.heading;
+      if (!headingType) return;
+      const command = setBlockType(headingType as never, { level });
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashQuote = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const blockquoteType = state.schema.nodes.blockquote;
+      if (!blockquoteType) return;
+      const command = wrapIn(blockquoteType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashBulletList = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const bulletListType = state.schema.nodes.bullet_list;
+      if (!bulletListType) return;
+      const command = wrapIn(bulletListType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashOrderedList = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const orderedListType = state.schema.nodes.ordered_list;
+      if (!orderedListType) return;
+      const command = wrapIn(orderedListType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashTaskList = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const bulletListType = state.schema.nodes.bullet_list;
+      const listItemType = state.schema.nodes.list_item;
+      if (!bulletListType || !listItemType) return;
+
+      const command = wrapIn(bulletListType as never);
+      command(state, dispatch);
+
+      const newState = view.state;
+      const tr = newState.tr;
+      const { from, to } = newState.selection;
+      newState.doc.nodesBetween(from, to, (node, pos) => {
+        if (node.type === listItemType && node.attrs.checked == null) {
+          tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked: false });
+        }
+      });
+      if (tr.docChanged) {
+        dispatch(tr);
+      }
+    });
+  };
+
+  const handleSlashInsertTable = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const commands = ctx.get(commandsCtx);
+      commands.call(insertTableCommand.key, { row: 3, col: 3 });
+    });
+  };
+
+  const handleSlashDivider = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const hrType = state.schema.nodes.hr;
+      if (!hrType) return;
+      const { $from } = state.selection;
+      const node = hrType.create();
+      const tr = state.tr.insert($from.pos, node);
+      dispatch(tr);
+    });
+  };
+
+  const handleSlashTag = () => {
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const { $from } = state.selection;
+      const codeType = state.schema.marks.code;
+      if (!codeType) return;
+
+      const tr = state.tr.insertText('#tag', $from.pos);
+      dispatch(tr);
+    });
+  };
+
+  const removeSlashTrigger = () => {
+    const range = slashMenuState.range;
+    if (!editor || !range) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const { from, to } = range;
+      const tr = state.tr.delete(from, to);
+      const cursorPos = from;
+      tr.setSelection(TextSelection.near(tr.doc.resolve(cursorPos)));
+      dispatch(tr);
+    });
+  };
+
+  const executeSlashAction = (action: () => void) => {
+    removeSlashTrigger();
+    closeSlashMenu();
+    setTimeout(() => {
+      action();
+      if (editor) {
+        editor.action((ctx) => {
+          const view = ctx.get(editorViewCtx);
+          if (view) {
+            view.focus();
+          }
+        });
+      }
+    }, 0);
+  };
+
+  const slashCommands = [
+    {
+      id: 'paragraph',
+      label: 'Paragraph',
+      hint: 'P',
+      shortcut: 'Ctrl+Alt+0',
+      keywords: ['paragraph', 'text', 'p'],
+      icon: <span className="text-xs">¶</span>,
+      onSelect: () => executeSlashAction(handleSlashParagraph),
+    },
+    {
+      id: 'h1',
+      label: 'Heading 1',
+      hint: 'H1',
+      shortcut: 'Ctrl+Alt+1',
+      keywords: ['heading', 'h1', 'title'],
+      icon: <IconH1 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(1)),
+    },
+    {
+      id: 'h2',
+      label: 'Heading 2',
+      hint: 'H2',
+      shortcut: 'Ctrl+Alt+2',
+      keywords: ['heading', 'h2'],
+      icon: <IconH2 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(2)),
+    },
+    {
+      id: 'h3',
+      label: 'Heading 3',
+      hint: 'H3',
+      shortcut: 'Ctrl+Alt+3',
+      keywords: ['heading', 'h3'],
+      icon: <IconH3 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(3)),
+    },
+    {
+      id: 'h4',
+      label: 'Heading 4',
+      hint: 'H4',
+      shortcut: 'Ctrl+Alt+4',
+      keywords: ['heading', 'h4'],
+      icon: <IconH4 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(4)),
+    },
+    {
+      id: 'h5',
+      label: 'Heading 5',
+      hint: 'H5',
+      shortcut: 'Ctrl+Alt+5',
+      keywords: ['heading', 'h5'],
+      icon: <IconH5 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(5)),
+    },
+    {
+      id: 'h6',
+      label: 'Heading 6',
+      hint: 'H6',
+      shortcut: 'Ctrl+Alt+6',
+      keywords: ['heading', 'h6'],
+      icon: <IconH6 size={16} />,
+      onSelect: () => executeSlashAction(() => handleSlashHeading(6)),
+    },
+    {
+      id: 'bold',
+      label: 'Bold',
+      hint: 'Bold',
+      shortcut: 'Ctrl+B',
+      keywords: ['bold', 'strong'],
+      icon: <IconBold size={16} />,
+      onSelect: () => executeSlashAction(handleBold),
+    },
+    {
+      id: 'italic',
+      label: 'Italic',
+      hint: 'Italic',
+      shortcut: 'Ctrl+I',
+      keywords: ['italic', 'emphasis'],
+      icon: <IconItalic size={16} />,
+      onSelect: () => executeSlashAction(handleItalic),
+    },
+    {
+      id: 'strikethrough',
+      label: 'Strikethrough',
+      hint: 'Strike',
+      shortcut: 'Ctrl+Shift+X',
+      keywords: ['strikethrough', 'strike'],
+      icon: <IconStrikethrough size={16} />,
+      onSelect: () => executeSlashAction(handleStrike),
+    },
+    {
+      id: 'code',
+      label: 'Code',
+      hint: 'Code',
+      shortcut: 'Ctrl+`',
+      keywords: ['code', 'inline'],
+      icon: <IconCode size={16} />,
+      onSelect: () => executeSlashAction(handleCode),
+    },
+    {
+      id: 'blockquote',
+      label: 'Blockquote',
+      hint: 'Quote',
+      shortcut: 'Ctrl+Shift+>',
+      keywords: ['quote', 'blockquote', 'citation'],
+      icon: <IconBlockquote size={16} />,
+      onSelect: () => executeSlashAction(handleSlashQuote),
+    },
+    {
+      id: 'link',
+      label: 'Link',
+      hint: 'Link',
+      shortcut: 'Ctrl+K',
+      keywords: ['link', 'url'],
+      icon: <IconLink size={16} />,
+      onSelect: () => executeSlashAction(handleLink),
+    },
+    {
+      id: 'bullet-list',
+      label: 'Bullet List',
+      hint: 'Bullet',
+      shortcut: 'Ctrl+Shift+8',
+      keywords: ['bullet', 'list', 'unordered'],
+      icon: <IconList size={16} />,
+      onSelect: () => executeSlashAction(handleSlashBulletList),
+    },
+    {
+      id: 'ordered-list',
+      label: 'Ordered List',
+      hint: 'Ordered',
+      shortcut: 'Ctrl+Shift+7',
+      keywords: ['ordered', 'list', 'number', 'numbered'],
+      icon: <IconListNumbers size={16} />,
+      onSelect: () => executeSlashAction(handleSlashOrderedList),
+    },
+    {
+      id: 'task-list',
+      label: 'Task List',
+      hint: 'Check',
+      shortcut: 'Ctrl+Shift+[',
+      keywords: ['task', 'check', 'list', 'todo', 'checkbox'],
+      icon: <IconListCheck size={16} />,
+      onSelect: () => executeSlashAction(handleSlashTaskList),
+    },
+    {
+      id: 'table',
+      label: 'Table',
+      hint: 'Table',
+      keywords: ['table', 'grid'],
+      icon: <IconTable size={16} />,
+      onSelect: () => executeSlashAction(handleSlashInsertTable),
+    },
+    {
+      id: 'image',
+      label: 'Image',
+      hint: 'Img',
+      shortcut: 'Ctrl+Shift+I',
+      keywords: ['image', 'photo', 'upload'],
+      icon: <IconPhoto size={16} />,
+      onSelect: () => executeSlashAction(handleImageUploadFromSlash),
+    },
+    {
+      id: 'divider',
+      label: 'Divider',
+      hint: 'Line',
+      keywords: ['divider', 'hr', 'line', 'separator', 'horizontal rule'],
+      icon: <span className="text-lg">—</span>,
+      onSelect: () => executeSlashAction(handleSlashDivider),
+    },
+    {
+      id: 'tag',
+      label: 'Tag',
+      hint: 'Tag',
+      shortcut: 'Ctrl+Shift+#',
+      keywords: ['tag', 'label', 'property', '#'],
+      icon: <span className="text-sm">#</span>,
+      onSelect: () => executeSlashAction(handleSlashTag),
+    },
+  ];
+
   const handleBold = () => {
     runMarkCommand('strong');
     setTimeout(updateActiveStates, 0);
@@ -426,6 +816,37 @@ export function MilkdownEditor({
       setTimeout(updateActiveStates, 0);
     }
   };
+
+  const handleBlockquote = () => {
+    if (!editor) return;
+    keepVisible();
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const blockquoteType = state.schema.nodes.blockquote;
+      if (!blockquoteType) return;
+
+      const { $from } = state.selection;
+      let inBlockquote = false;
+
+      state.doc.nodesBetween($from.pos, $from.pos, (node) => {
+        if (node.type === blockquoteType) {
+          inBlockquote = true;
+        }
+      });
+
+      if (inBlockquote) {
+        const command = lift;
+        command(state, dispatch);
+      } else {
+        const command = wrapIn(blockquoteType as never);
+        command(state, dispatch);
+      }
+    });
+    setTimeout(updateActiveStates, 0);
+  };
+
   const handleImageUpload = async (file: File) => {
     if (!workspaceId) {
       alert('No workspace selected');
@@ -467,6 +888,19 @@ export function MilkdownEditor({
     } catch (e) {
       alert(`Upload failed: ${(e as Error).message}`);
     }
+  };
+
+  const handleImageUploadFromSlash = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        handleImageUpload(file);
+      }
+    };
+    input.click();
   };
   const handleH1 = () => {
     runBlockCommand('heading', { level: 1 });
@@ -727,6 +1161,13 @@ export function MilkdownEditor({
         onClose={closeSuggestions}
         onAddPage={handleAddPage}
       />
+      <SlashMenu
+        isOpen={slashMenuState.isOpen}
+        query={slashMenuState.query}
+        position={slashMenuState.position}
+        commands={slashCommands}
+        onClose={closeSlashMenu}
+      />
       <FloatingToolbar
         visible={visible}
         position={position}
@@ -735,6 +1176,7 @@ export function MilkdownEditor({
         onStrike={handleStrike}
         onCode={handleCode}
         onLink={handleLink}
+        onBlockquote={handleBlockquote}
         onImageUpload={handleImageUpload}
         onH1={handleH1}
         onH2={handleH2}

--- a/packages/web/src/components/editor/SlashMenu.tsx
+++ b/packages/web/src/components/editor/SlashMenu.tsx
@@ -1,0 +1,199 @@
+import Fuse from 'fuse.js';
+import type React from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+export interface SlashCommandItem {
+  id: string;
+  label: string;
+  hint: string;
+  shortcut?: string;
+  keywords: string[];
+  icon: React.ReactNode;
+  onSelect: () => void;
+}
+
+interface SlashMenuProps {
+  isOpen: boolean;
+  query: string;
+  position: { x: number; y: number; top?: number; bottom?: number } | null;
+  commands: SlashCommandItem[];
+  onClose: () => void;
+}
+
+const MENU_WIDTH = 320;
+const MENU_OVERFLOW_THRESHOLD = 320;
+
+export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashMenuProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({
+    opacity: 0,
+    pointerEvents: 'none',
+  });
+  const [placement, setPlacement] = useState<'top' | 'bottom'>('bottom');
+  const trimmedQuery = query.trim();
+
+  const fuse = useMemo(() => {
+    return new Fuse(commands, {
+      keys: ['label', 'keywords'],
+      threshold: 0.35,
+      distance: 100,
+      ignoreLocation: true,
+    });
+  }, [commands]);
+
+  const results = useMemo(() => {
+    if (!trimmedQuery) return commands;
+    return fuse.search(trimmedQuery).map((result) => result.item);
+  }, [commands, fuse, trimmedQuery]);
+
+  useEffect(() => {
+    if (isOpen) setSelectedIndex(0);
+  }, [isOpen]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !position || !containerRef.current) {
+      if (!isOpen) {
+        setMenuStyle({ opacity: 0, pointerEvents: 'none' });
+      }
+      return;
+    }
+
+    const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
+    const x = position.x;
+    const bottomCoord = position.bottom ?? position.y;
+    const topCoord = position.top ?? position.y - 20;
+    const nextPlacement =
+      bottomCoord + MENU_OVERFLOW_THRESHOLD > viewportHeight - 20 ? 'top' : 'bottom';
+
+    setPlacement(nextPlacement);
+
+    const style: React.CSSProperties = {
+      position: 'fixed',
+      left: Math.max(20, Math.min(x, viewportWidth - MENU_WIDTH - 20)),
+      opacity: 1,
+      pointerEvents: 'auto',
+      zIndex: 100,
+    };
+
+    if (nextPlacement === 'top') {
+      style.bottom = viewportHeight - topCoord + 8;
+    } else {
+      style.top = bottomCoord + 4;
+    }
+
+    setMenuStyle(style);
+  }, [isOpen, position]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const selectedElement = containerRef.current?.querySelector(
+      `button:nth-child(${selectedIndex + 2})`,
+    ) as HTMLElement | undefined;
+    if (selectedElement) {
+      selectedElement.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex((prev) => (results.length === 0 ? 0 : (prev + 1) % results.length));
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        event.stopPropagation();
+        setSelectedIndex((prev) =>
+          results.length === 0 ? 0 : (prev - 1 + results.length) % results.length,
+        );
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        const selected = results[selectedIndex];
+        if (!selected) return;
+        event.preventDefault();
+        event.stopPropagation();
+        selected.onSelect();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [isOpen, onClose, results, selectedIndex]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (containerRef.current.contains(event.target as Node)) return;
+      onClose();
+    };
+
+    window.addEventListener('mousedown', handleClickOutside);
+    return () => window.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="slash-menu"
+      className={`w-80 max-w-[calc(100vw-2rem)] rounded-xl border shadow-2xl overflow-hidden animate-in fade-in duration-100 ${
+        placement === 'bottom'
+          ? 'zoom-in-95 slide-in-from-top-2'
+          : 'zoom-in-95 slide-in-from-bottom-2'
+      } bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-zinc-100`}
+      style={menuStyle}
+    >
+      <div className="px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-500 border-b border-zinc-100 dark:border-zinc-800/50">
+        Insert block
+      </div>
+
+      <div className="max-h-[300px] overflow-y-auto p-1.5 space-y-0.5 scrollbar-thin scrollbar-thumb-zinc-200 dark:scrollbar-thumb-zinc-800">
+        {results.length === 0 ? (
+          <div className="px-3 py-4 text-center text-sm text-zinc-500">No matching commands</div>
+        ) : (
+          results.map((command, index) => (
+            <button
+              key={command.id}
+              type="button"
+              onClick={command.onSelect}
+              className={`flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-sm transition-all cursor-pointer ${
+                index === selectedIndex
+                  ? 'bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-50 shadow-sm'
+                  : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 hover:text-zinc-900 dark:hover:text-zinc-300'
+              }`}
+            >
+              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-zinc-100 dark:bg-zinc-800/80 border border-zinc-200 dark:border-zinc-700/50 text-xs font-semibold">
+                {command.icon}
+              </span>
+              <span className="min-w-0 flex-1 truncate font-medium">{command.label}</span>
+              {command.shortcut && (
+                <span className="text-xs text-zinc-500 dark:text-zinc-500 font-mono ml-auto pl-2">
+                  {command.shortcut}
+                </span>
+              )}
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/editor/SlashMenu.tsx
+++ b/packages/web/src/components/editor/SlashMenu.tsx
@@ -51,6 +51,10 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
     if (isOpen) setSelectedIndex(0);
   }, [isOpen]);
 
+  useEffect(() => {
+    setSelectedIndex((prev) => Math.min(prev, Math.max(0, results.length - 1)));
+  }, [results]);
+
   useLayoutEffect(() => {
     if (!isOpen || !position || !containerRef.current) {
       if (!isOpen) {
@@ -89,9 +93,10 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
   useEffect(() => {
     if (!isOpen) return;
 
-    const selectedElement = containerRef.current?.querySelector(
-      `button:nth-child(${selectedIndex + 2})`,
-    ) as HTMLElement | undefined;
+    const buttons = containerRef.current?.querySelectorAll<HTMLElement>(
+      ':scope button',
+    );
+    const selectedElement = buttons?.[selectedIndex];
     if (selectedElement) {
       selectedElement.scrollIntoView({ block: 'nearest' });
     }

--- a/packages/web/src/components/editor/SlashMenu.tsx
+++ b/packages/web/src/components/editor/SlashMenu.tsx
@@ -93,9 +93,7 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
   useEffect(() => {
     if (!isOpen) return;
 
-    const buttons = containerRef.current?.querySelectorAll<HTMLElement>(
-      ':scope button',
-    );
+    const buttons = containerRef.current?.querySelectorAll<HTMLElement>(':scope button');
     const selectedElement = buttons?.[selectedIndex];
     if (selectedElement) {
       selectedElement.scrollIntoView({ block: 'nearest' });

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -161,6 +161,12 @@ interface UseMilkdownProps {
     query: string,
     position: { x: number; y: number; top?: number; bottom?: number } | null,
   ) => void;
+  onSlashMenuSuggest?: (
+    isOpen: boolean,
+    query: string,
+    position: { x: number; y: number; top?: number; bottom?: number } | null,
+    range: { from: number; to: number } | null,
+  ) => void;
 }
 
 function isTaskChecked(checked: unknown): boolean {
@@ -213,6 +219,7 @@ export function useMilkdown({
   provider,
   onWikiLinkClick,
   onWikiLinkSuggest,
+  onSlashMenuSuggest,
 }: UseMilkdownProps) {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const editorRef = useRef<Editor | null>(null);
@@ -221,6 +228,8 @@ export function useMilkdown({
   onWikiLinkClickRef.current = onWikiLinkClick;
   const onWikiLinkSuggestRef = useRef(onWikiLinkSuggest);
   onWikiLinkSuggestRef.current = onWikiLinkSuggest;
+  const onSlashMenuSuggestRef = useRef(onSlashMenuSuggest);
+  onSlashMenuSuggestRef.current = onSlashMenuSuggest;
   const hasCollab = Boolean(doc && provider);
   const fallbackInitialValue = hasCollab ? undefined : initialValue;
 
@@ -324,13 +333,14 @@ export function useMilkdown({
 
           ctx.get(listenerCtx).updated((_ctx) => {
             const suggest = onWikiLinkSuggestRef.current;
-            if (!suggest) return;
+            const suggestSlash = onSlashMenuSuggestRef.current;
 
             const view = _ctx.get(editorViewCtx);
             const { selection } = view.state;
 
             if (!selection.empty) {
-              suggest(false, '', null);
+              suggest?.(false, '', null);
+              suggestSlash?.(false, '', null, null);
               return;
             }
 
@@ -341,14 +351,46 @@ export function useMilkdown({
             if (match) {
               const query = match[1] || '';
               const coords = view.coordsAtPos($from.pos);
-              suggest(true, query, {
+              suggest?.(true, query, {
                 x: coords.left,
                 y: coords.bottom + 5,
                 top: coords.top,
                 bottom: coords.bottom,
               });
+              suggestSlash?.(false, '', null, null);
             } else {
-              suggest(false, '', null);
+              suggest?.(false, '', null);
+
+              if (!suggestSlash) {
+                return;
+              }
+
+              const slashIndex = textBefore.lastIndexOf('/');
+              if (slashIndex < 0) {
+                suggestSlash(false, '', null, null);
+                return;
+              }
+
+              const prefixChar = slashIndex === 0 ? '' : (textBefore[slashIndex - 1] ?? '');
+              if (prefixChar && !/\s/.test(prefixChar)) {
+                suggestSlash(false, '', null, null);
+                return;
+              }
+
+              const query = textBefore.slice(slashIndex + 1);
+              const coords = view.coordsAtPos($from.pos);
+              const slashFrom = $from.start() + slashIndex;
+              suggestSlash(
+                true,
+                query,
+                {
+                  x: coords.left,
+                  y: coords.bottom + 5,
+                  top: coords.top,
+                  bottom: coords.bottom,
+                },
+                { from: slashFrom, to: $from.pos },
+              );
             }
           });
 


### PR DESCRIPTION
## Summary

Adds a slash menu (`/`) to the Milkdown editor for inserting blocks and applying formatting without leaving the keyboard. Includes 18 commands covering headings, lists, formatting, tables, dividers, tags, and more.

## Changes

### Slash menu infrastructure
- **`SlashMenu` component** — fuzzy-searchable popup with Fuse.js, keyboard navigation (ArrowUp/Down/Enter/Escape), smart viewport positioning (flips above/below), click-outside dismissal
- **`useMilkdown` hook** — detects `/` at line start (or after whitespace) and emits query + cursor range for the slash menu; maintains correct precedence with existing `[[` wiki link detection

### Editor integration  
- **18 slash commands**: paragraph, heading 1–6, bold, italic, strikethrough, inline code, blockquote, link, bullet/ordered/task list, table, image, divider, tag
- Commands cleanly remove the `/query` trigger text before executing via `setBlockType`, `wrapIn`, `toggleMark`, or custom ProseMirror transactions
- Blockquote toggle in floating toolbar now correctly detects being inside a blockquote (uses `hasParentBlockType` instead of broken `nodesBetween(==)`)
- Tag command inserts `#tag` text for the existing Milkdown tag plugin to process

### Bug fixes
- **Scroll-into-view**: fixed `button:nth-child()` selector that never matched — buttons are nested inside a child `div`, not direct children of the container
- **SelectedIndex bounds**: clamped when `results` array shrinks on filter change, preventing silent no-ops on Enter
- **handleSlashTag**: removed dead `state.schema.marks.code` lookup that used the wrong mark name and caused silent no-ops
  
### Testing
- **20 E2E scenarios** across Chromium and Firefox (41 tests total): trigger behavior, fuzzy search, dismissal (Escape + click-outside), keyboard navigation, trigger cleanup, all block command types, inline marks, sequential use, and wiki link coexistence regression
- **`e2e/AGENTS.md`** documenting how to run E2E tests locally (auth setup, stale DB cleanup, working directory requirements)

### Other
- Blockquote button added to floating toolbar
- Divider between code and link toolbar buttons removed for layout consistency

## Commits

```
a0c732f feat(editor): add slash menu detection to useMilkdown hook
208e780 feat(editor): add slash menu component
fcc0476 feat(editor): integrate slash menu into editor
4781c0c feat(editor): add blockquote button to floating toolbar
0d7bdd5 test(e2e): add slash menu E2E tests
2202b0b test(e2e): expand slash menu coverage to 20 scenarios
52666ae fix(editor): repair scroll-into-view, blockquote toggle, selectedIndex bounds, and tag command
```