### PR TITLE
fix(web): list option toggle, alignment, and active state highlighting

### DIFF
--- a/e2e/editor/toolbar.spec.ts
+++ b/e2e/editor/toolbar.spec.ts
@@ -101,6 +101,77 @@ test.describe('Floating toolbar buttons', () => {
     await expect(page.locator('li[data-item-type="task"]')).toBeVisible({ timeout: 5000 });
   });
 
+  test('toggles off list formatting when toolbar button clicked again', async ({ page }) => {
+    await createNewPage(page);
+    await focusEditor(page);
+
+    await page.keyboard.type('Bullet');
+    await page.keyboard.press('Control+a');
+    await page.locator('.floating-toolbar button[title="Bullet List"]').click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ul')).toBeVisible({ timeout: 5000 });
+    await page.locator('.floating-toolbar button[title="Bullet List"]').click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ul')).toHaveCount(0);
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+
+    await page.keyboard.type('Ordered');
+    await page.keyboard.press('Control+a');
+    await page.locator('.floating-toolbar button[title="Ordered List"]').click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ol')).toBeVisible({ timeout: 5000 });
+    await page.locator('.floating-toolbar button[title="Ordered List"]').click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ol')).toHaveCount(0);
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+
+    await page.keyboard.type('Task');
+    await page.keyboard.press('Control+a');
+    await page.locator('.floating-toolbar button[title="Task List"]').click({ timeout: 5000 });
+    await expect(page.locator('li[data-item-type="task"]')).toBeVisible({ timeout: 5000 });
+    await page.locator('.floating-toolbar button[title="Task List"]').click({ timeout: 5000 });
+    await expect(page.locator('li[data-item-type="task"]')).toHaveCount(0);
+  });
+
+  test('highlights correct toolbar icon for active list type', async ({ page }) => {
+    await createNewPage(page);
+    await focusEditor(page);
+
+    const bulletBtn = page.locator('.floating-toolbar button[title="Bullet List"]');
+    const orderedBtn = page.locator('.floating-toolbar button[title="Ordered List"]');
+    const taskBtn = page.locator('.floating-toolbar button[title="Task List"]');
+
+    await page.keyboard.type('Task item');
+    await page.keyboard.press('Control+a');
+    await taskBtn.click({ timeout: 5000 });
+    await expect(page.locator('li[data-item-type="task"]')).toBeVisible({ timeout: 5000 });
+    await expect(taskBtn).toHaveClass(/bg-zinc-600/);
+    await expect(bulletBtn).not.toHaveClass(/bg-zinc-600/);
+    await expect(orderedBtn).not.toHaveClass(/bg-zinc-600/);
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+    await taskBtn.click({ timeout: 5000 });
+    await expect(page.locator('li[data-item-type="task"]')).toHaveCount(0);
+
+    await page.keyboard.type('Bullet item');
+    await page.keyboard.press('Control+a');
+    await bulletBtn.click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ul')).toBeVisible({ timeout: 5000 });
+    await expect(bulletBtn).toHaveClass(/bg-zinc-600/);
+    await expect(taskBtn).not.toHaveClass(/bg-zinc-600/);
+    await expect(orderedBtn).not.toHaveClass(/bg-zinc-600/);
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('Enter');
+    await bulletBtn.click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ul')).toHaveCount(0);
+
+    await page.keyboard.type('Ordered item');
+    await page.keyboard.press('Control+a');
+    await orderedBtn.click({ timeout: 5000 });
+    await expect(page.locator('.ProseMirror ol')).toBeVisible({ timeout: 5000 });
+    await expect(orderedBtn).toHaveClass(/bg-zinc-600/);
+    await expect(bulletBtn).not.toHaveClass(/bg-zinc-600/);
+    await expect(taskBtn).not.toHaveClass(/bg-zinc-600/);
+  });
+
   test('insert table via toolbar', async ({ page }) => {
     await createNewPage(page);
     await focusEditor(page);

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -50,6 +50,17 @@ import { FloatingToolbar } from './FloatingToolbar';
 import { SlashMenu } from './SlashMenu';
 import { WikiLinkSuggestions } from './WikiLinkSuggestions';
 
+function hasTaskListAncestor(state: EditorState): boolean {
+  const listItemType = state.schema.nodes.list_item;
+  if (!listItemType) return false;
+  const { $from } = state.selection;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type === listItemType && node.attrs.checked != null) return true;
+  }
+  return false;
+}
+
 function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
   const { $from } = state.selection;
   const schema = state.schema;
@@ -962,7 +973,7 @@ export function MilkdownEditor({
       const listItemType = state.schema.nodes.list_item;
       if (!bulletListType || !listItemType || !dispatch) return;
 
-      if (activeStates.isBulletListActive) {
+      if (hasParentBlockType(state, bulletListType) && !hasTaskListAncestor(state)) {
         unwrapList(state, dispatch);
       } else {
         wrapIn(bulletListType as never)(state, dispatch);
@@ -978,9 +989,10 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const orderedListType = state.schema.nodes.ordered_list;
-      if (!orderedListType || !dispatch) return;
+      const listItemType = state.schema.nodes.list_item;
+      if (!orderedListType || !listItemType || !dispatch) return;
 
-      if (activeStates.isOrderedListActive) {
+      if (hasParentBlockType(state, orderedListType)) {
         unwrapList(state, dispatch);
       } else {
         wrapIn(orderedListType as never)(state, dispatch);
@@ -999,7 +1011,7 @@ export function MilkdownEditor({
       const listItemType = state.schema.nodes.list_item;
       if (!bulletListType || !listItemType || !dispatch) return;
 
-      if (activeStates.isTaskListActive) {
+      if (hasTaskListAncestor(state)) {
         unwrapList(state, dispatch);
       } else {
         const command = wrapIn(bulletListType as never);

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -33,7 +33,7 @@ import type { EditorView } from '@milkdown/kit/prose/view';
 import { insertTableCommand } from '@milkdown/preset-gfm';
 import { lift, setBlockType, toggleMark, wrapIn } from 'prosemirror-commands';
 import type { MarkType, NodeType } from 'prosemirror-model';
-import type { EditorState } from 'prosemirror-state';
+import type { EditorState, Transaction } from 'prosemirror-state';
 import { TextSelection } from 'prosemirror-state';
 import {
   addColumnAfter,
@@ -49,6 +49,43 @@ import * as Y from 'yjs';
 import { FloatingToolbar } from './FloatingToolbar';
 import { SlashMenu } from './SlashMenu';
 import { WikiLinkSuggestions } from './WikiLinkSuggestions';
+
+function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => void): boolean {
+  const { $from } = state.selection;
+  const schema = state.schema;
+
+  let listDepth = -1;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type === schema.nodes.bullet_list || node.type === schema.nodes.ordered_list) {
+      listDepth = d;
+      break;
+    }
+  }
+  if (listDepth < 0) return false;
+
+  const listStart = $from.before(listDepth);
+  const listEnd = $from.after(listDepth);
+  const listNode = $from.node(listDepth);
+  const listItemType = schema.nodes.list_item;
+
+  const content: unknown[] = [];
+  for (let i = 0; i < listNode.content.childCount; i++) {
+    const child = listNode.content.child(i);
+    if (child.type === listItemType) {
+      for (let j = 0; j < child.content.childCount; j++) {
+        content.push(child.content.child(j));
+      }
+    }
+  }
+
+  if (content.length === 0) return false;
+  if (dispatch) {
+    const tr = state.tr.replaceWith(listStart, listEnd, content as never);
+    dispatch(tr.scrollIntoView());
+  }
+  return true;
+}
 
 interface MilkdownEditorProps {
   pageId: string;
@@ -198,20 +235,18 @@ export function MilkdownEditor({
 
         const listItemNode = nodes.list_item;
         const isInListItem = listItemNode ? hasParentBlockType(state, listItemNode) : false;
-        const listItemChecked =
-          isInListItem && listItemNode
-            ? (() => {
-                const { $from } = state.selection;
-                for (let d = $from.depth; d > 0; d--) {
-                  const node = $from.node(d);
-                  if (node.type === listItemNode) {
-                    const checked = node.attrs.checked;
-                    return checked === true || checked === 'true';
-                  }
-                }
-                return false;
-              })()
-            : false;
+
+        let isTaskListItem = false;
+        if (isInListItem && listItemNode) {
+          const { $from } = state.selection;
+          for (let d = $from.depth; d > 0; d--) {
+            const node = $from.node(d);
+            if (node.type === listItemNode && node.attrs.checked != null) {
+              isTaskListItem = true;
+              break;
+            }
+          }
+        }
 
         setActiveStates({
           isBoldActive: hasMark(state, marks.strong),
@@ -226,9 +261,9 @@ export function MilkdownEditor({
           isH4Active: hasBlockType(state, nodes.heading, { level: 4 }),
           isH5Active: hasBlockType(state, nodes.heading, { level: 5 }),
           isH6Active: hasBlockType(state, nodes.heading, { level: 6 }),
-          isBulletListActive: hasParentBlockType(state, nodes.bullet_list) && !listItemChecked,
+          isBulletListActive: hasParentBlockType(state, nodes.bullet_list) && !isTaskListItem,
           isOrderedListActive: hasParentBlockType(state, nodes.ordered_list),
-          isTaskListActive: listItemChecked,
+          isTaskListActive: isTaskListItem,
           isInTableActive: isInTable(state),
         });
       });
@@ -924,9 +959,14 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const bulletListType = state.schema.nodes.bullet_list;
-      if (!bulletListType) return;
-      const command = wrapIn(bulletListType as never);
-      command(state, dispatch);
+      const listItemType = state.schema.nodes.list_item;
+      if (!bulletListType || !listItemType || !dispatch) return;
+
+      if (activeStates.isBulletListActive) {
+        unwrapList(state, dispatch);
+      } else {
+        wrapIn(bulletListType as never)(state, dispatch);
+      }
     });
     setTimeout(updateActiveStates, 0);
   };
@@ -938,9 +978,13 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const orderedListType = state.schema.nodes.ordered_list;
-      if (!orderedListType) return;
-      const command = wrapIn(orderedListType as never);
-      command(state, dispatch);
+      if (!orderedListType || !dispatch) return;
+
+      if (activeStates.isOrderedListActive) {
+        unwrapList(state, dispatch);
+      } else {
+        wrapIn(orderedListType as never)(state, dispatch);
+      }
     });
     setTimeout(updateActiveStates, 0);
   };
@@ -955,19 +999,23 @@ export function MilkdownEditor({
       const listItemType = state.schema.nodes.list_item;
       if (!bulletListType || !listItemType || !dispatch) return;
 
-      const command = wrapIn(bulletListType as never);
-      command(state, dispatch);
+      if (activeStates.isTaskListActive) {
+        unwrapList(state, dispatch);
+      } else {
+        const command = wrapIn(bulletListType as never);
+        command(state, dispatch);
 
-      const newState = view.state;
-      const tr = newState.tr;
-      const { from, to } = newState.selection;
-      newState.doc.nodesBetween(from, to, (node, pos) => {
-        if (node.type === listItemType && node.attrs.checked == null) {
-          tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked: false });
+        const newState = view.state;
+        const tr = newState.tr;
+        const { from, to } = newState.selection;
+        newState.doc.nodesBetween(from, to, (node, pos) => {
+          if (node.type === listItemType && node.attrs.checked == null) {
+            tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked: false });
+          }
+        });
+        if (tr.docChanged) {
+          dispatch(tr);
         }
-      });
-      if (tr.docChanged) {
-        dispatch(tr);
       }
     });
     setTimeout(updateActiveStates, 0);

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -67,6 +67,7 @@ function hasTaskListAncestor(state: EditorState): boolean {
         found = true;
         return false;
       }
+      return;
     });
     return found;
   }

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -58,6 +58,18 @@ function hasTaskListAncestor(state: EditorState): boolean {
     const node = $from.node(d);
     if (node.type === listItemType && node.attrs.checked != null) return true;
   }
+  // Handle AllSelection / depth-0: search the full selection range
+  if ($from.depth === 0) {
+    const { from, to } = state.selection;
+    let found = false;
+    state.doc.nodesBetween(from, to, (node) => {
+      if (node.type === listItemType && node.attrs.checked != null) {
+        found = true;
+        return false;
+      }
+    });
+    return found;
+  }
   return false;
 }
 
@@ -65,21 +77,39 @@ function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => void): b
   const { $from } = state.selection;
   const schema = state.schema;
 
-  let listDepth = -1;
+  let listStart = -1;
+  let listEnd = -1;
+  let listNode: import('prosemirror-model').Node | null = null;
+
+  // First try: traverse ancestors from cursor position
   for (let d = $from.depth; d > 0; d--) {
     const node = $from.node(d);
     if (node.type === schema.nodes.bullet_list || node.type === schema.nodes.ordered_list) {
-      listDepth = d;
+      listStart = $from.before(d);
+      listEnd = $from.after(d);
+      listNode = node;
       break;
     }
   }
-  if (listDepth < 0) return false;
 
-  const listStart = $from.before(listDepth);
-  const listEnd = $from.after(listDepth);
-  const listNode = $from.node(listDepth);
+  // Fallback for AllSelection / depth-0: find the list among direct doc children
+  if (!listNode && $from.depth === 0) {
+    let pos = 0;
+    for (let i = 0; i < state.doc.content.childCount; i++) {
+      const child = state.doc.content.child(i);
+      if (child.type === schema.nodes.bullet_list || child.type === schema.nodes.ordered_list) {
+        listStart = pos;
+        listEnd = pos + child.nodeSize;
+        listNode = child;
+        break;
+      }
+      pos += child.nodeSize;
+    }
+  }
+
+  if (!listNode) return false;
+
   const listItemType = schema.nodes.list_item;
-
   const content: unknown[] = [];
   for (let i = 0; i < listNode.content.childCount; i++) {
     const child = listNode.content.child(i);
@@ -93,6 +123,11 @@ function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => void): b
   if (content.length === 0) return false;
   if (dispatch) {
     const tr = state.tr.replaceWith(listStart, listEnd, content as never);
+    // Collapse selection to cursor at end of unwrapped content,
+    // combined with view.focus() in the caller this ensures
+    // ProseMirror's updateSelection() fires and the cursor lands correctly.
+    const afterSize = tr.doc.content.size;
+    tr.setSelection(TextSelection.near(tr.doc.resolve(Math.max(1, afterSize - 1))));
     dispatch(tr.scrollIntoView());
   }
   return true;
@@ -224,6 +259,14 @@ export function MilkdownEditor({
         return true;
       }
     }
+    // Handle AllSelection / depth-0: check doc's direct children
+    if (depth === 0) {
+      for (let i = 0; i < state.doc.content.childCount; i++) {
+        if (state.doc.content.child(i).type === nodeType) {
+          return true;
+        }
+      }
+    }
     return false;
   }, []);
 
@@ -244,20 +287,7 @@ export function MilkdownEditor({
         const marks = schema.marks;
         const nodes = schema.nodes;
 
-        const listItemNode = nodes.list_item;
-        const isInListItem = listItemNode ? hasParentBlockType(state, listItemNode) : false;
-
-        let isTaskListItem = false;
-        if (isInListItem && listItemNode) {
-          const { $from } = state.selection;
-          for (let d = $from.depth; d > 0; d--) {
-            const node = $from.node(d);
-            if (node.type === listItemNode && node.attrs.checked != null) {
-              isTaskListItem = true;
-              break;
-            }
-          }
-        }
+        const isTaskListItem = hasTaskListAncestor(state);
 
         setActiveStates({
           isBoldActive: hasMark(state, marks.strong),
@@ -979,6 +1009,14 @@ export function MilkdownEditor({
         wrapIn(bulletListType as never)(state, dispatch);
       }
     });
+    // Refocus after React state from keepVisible() settles so the
+    // toolbar DOM isn't torn down during a concurrent test click.
+    setTimeout(() => {
+      editor?.action((ctx) => {
+        const v = ctx.get(editorViewCtx);
+        if (v && !v.hasFocus()) v.focus();
+      });
+    }, 0);
     setTimeout(updateActiveStates, 0);
   };
   const handleOrderedList = () => {
@@ -998,6 +1036,12 @@ export function MilkdownEditor({
         wrapIn(orderedListType as never)(state, dispatch);
       }
     });
+    setTimeout(() => {
+      editor?.action((ctx) => {
+        const v = ctx.get(editorViewCtx);
+        if (v && !v.hasFocus()) v.focus();
+      });
+    }, 0);
     setTimeout(updateActiveStates, 0);
   };
   const handleTaskList = () => {
@@ -1030,6 +1074,12 @@ export function MilkdownEditor({
         }
       }
     });
+    setTimeout(() => {
+      editor?.action((ctx) => {
+        const v = ctx.get(editorViewCtx);
+        if (v && !v.hasFocus()) v.focus();
+      });
+    }, 0);
     setTimeout(updateActiveStates, 0);
   };
 

--- a/packages/web/src/components/editor/editor.css
+++ b/packages/web/src/components/editor/editor.css
@@ -57,22 +57,31 @@
   margin-bottom: 1rem;
 }
 
+.milkdown-editor-view ul li::marker {
+  font-size: 1.2em;
+}
+
+.milkdown-editor-view ol li::marker {
+  font-size: 1.2em;
+}
+
 .milkdown-editor-view li[data-item-type="task"] {
   list-style: none;
   position: relative;
-  padding-left: 1.75rem;
+  padding-left: 0;
 }
 
 .milkdown-editor-view li[data-item-type="task"]::before {
   content: "";
   position: absolute;
-  left: 0;
+  left: -1.25rem;
   top: 0.38em;
   width: 14px;
   height: 14px;
   border: 1px solid #6b7280;
   border-radius: 4px;
   background: transparent;
+  box-sizing: border-box;
 }
 
 .milkdown-editor-view li[data-item-type="task"][data-checked="true"]::before {


### PR DESCRIPTION
## Summary

Closes #48:

1. **Visual alignment** — Checklist items now align with bullet/numbered lists. Removed the extra `padding-left` on task items and positioned the checkbox in the marker area.

2. **Toolbar toggle behavior** — Bullet, ordered, and task list buttons now toggle off when clicked again instead of being one-way switches. Replaced `liftListItem` (which silently fails on multi-item lists) with a custom `unwrapList` helper that properly converts the entire list back to paragraphs, handling multi-item and nested structures.

3. **Correct icon highlighting** — Previously, unchecked task items would light up the bullet list icon instead of the task list icon. Fixed by checking `checked != null` instead of `checked === true` to detect task items regardless of check state.

## Changes

| File | Change |
|---|---|
| `MilkdownEditor.tsx` | Custom `unwrapList` helper; toggle logic for all three list buttons; fixed task item detection |
| `editor.css` | Task item padding/positioning; `ol li::marker` sizing; `box-sizing` on checkbox |
| `toolbar.spec.ts` | E2E tests for toggle-off behavior and active state highlighting |