### PR TITLE
refactor(web): remove mantine ui library

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,9 +20,7 @@
     "@fontsource/inter": "^5.2.8",
     "@hocuspocus/provider": "^3.4.4",
     "@logtape/logtape": "^2.0.5",
-    "@mantine/core": "^8.3.15",
-    "@mantine/hooks": "^8.3.15",
-    "@mantine/notifications": "^8.3.15",
+
     "@markdawn/shared": "workspace:*",
     "@milkdown/components": "^7.20.0",
     "@milkdown/core": "^7.0.0",

--- a/packages/web/src/components/EmojiPicker.tsx
+++ b/packages/web/src/components/EmojiPicker.tsx
@@ -1,8 +1,8 @@
 import data from '@emoji-mart/data';
 import Picker from '@emoji-mart/react';
-import { Popover } from '@mantine/core';
 import type React from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { Popover } from '../components/ui/popover';
 import { useTheme } from '../hooks/useTheme';
 
 interface EmojiPickerProps {
@@ -14,41 +14,42 @@ interface EmojiPickerProps {
 export function EmojiPicker({ icon, onChange, children }: EmojiPickerProps) {
   const [opened, setOpened] = useState(false);
   const { isDark } = useTheme();
+  const targetRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <Popover
-      opened={opened}
-      onChange={setOpened}
-      position="bottom-start"
-      withArrow
-      shadow="md"
-      transitionProps={{ transition: 'pop', duration: 150 }}
-    >
-      <Popover.Target>
-        <button
-          type="button"
-          onClick={() => setOpened((o) => !o)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setOpened((o) => !o);
-            }
+    <Popover opened={opened} onChange={setOpened}>
+      <button
+        ref={targetRef}
+        type="button"
+        onClick={() => setOpened((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpened((o) => !o);
+          }
+        }}
+        className="cursor-pointer inline-block bg-transparent border-none p-0"
+      >
+        {children}
+      </button>
+      {opened && (
+        <div
+          className="absolute z-50 animate-scale-in"
+          style={{
+            top: targetRef.current ? targetRef.current.offsetHeight + 4 : 0,
+            left: 0,
           }}
-          className="cursor-pointer inline-block bg-transparent border-none p-0"
         >
-          {children}
-        </button>
-      </Popover.Target>
-      <Popover.Dropdown p={0} className="border-none bg-transparent">
-        <Picker
-          data={data}
-          onEmojiSelect={(emoji: { native: string }) => {
-            onChange(emoji.native);
-            setOpened(false);
-          }}
-          theme={isDark ? 'dark' : 'light'}
-        />
-      </Popover.Dropdown>
+          <Picker
+            data={data}
+            onEmojiSelect={(emoji: { native: string }) => {
+              onChange(emoji.native);
+              setOpened(false);
+            }}
+            theme={isDark ? 'dark' : 'light'}
+          />
+        </div>
+      )}
     </Popover>
   );
 }

--- a/packages/web/src/components/editor/CoverPicker.tsx
+++ b/packages/web/src/components/editor/CoverPicker.tsx
@@ -1,7 +1,7 @@
-import { ActionIcon, Button, Group, Popover, Stack, Text, Tooltip } from '@mantine/core';
-import { IconPhoto, IconTrash } from '@tabler/icons-react';
+import { IconTrash } from '@tabler/icons-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { Tooltip } from '../Tooltip';
 
 interface CoverPickerProps {
   coverType: string | null;
@@ -42,95 +42,102 @@ const SOLID_COLORS = [
 
 export function CoverPicker({ coverType, coverValue, onChange, children }: CoverPickerProps) {
   const [opened, setOpened] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLButtonElement>(null);
 
   return (
-    <Popover
-      opened={opened}
-      onChange={setOpened}
-      position="bottom-start"
-      withArrow
-      shadow="md"
-      transitionProps={{ transition: 'pop', duration: 150 }}
-    >
-      <Popover.Target>
-        <button
-          type="button"
-          onClick={() => setOpened((o) => !o)}
-          className="cursor-pointer inline-block bg-transparent border-none p-0"
-        >
-          {children}
-        </button>
-      </Popover.Target>
-      <Popover.Dropdown className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-4 rounded-lg shadow-xl w-80 min-w-[20rem]">
-        <Stack gap="md">
-          <div>
-            <Group justify="space-between" mb="xs">
-              <Text size="sm" fw={500} className="text-zinc-700 dark:text-zinc-300">
-                Gradients
-              </Text>
-              {(coverType || coverValue) && (
-                <Tooltip label="Remove cover">
-                  <ActionIcon
-                    variant="subtle"
-                    color="red"
-                    size="sm"
-                    onClick={() => {
-                      onChange(null, null);
-                      setOpened(false);
-                    }}
-                  >
-                    <IconTrash size={14} />
-                  </ActionIcon>
-                </Tooltip>
-              )}
-            </Group>
-            <div className="grid grid-cols-4 gap-2">
-              {GRADIENTS.map((gradient) => (
-                <button
-                  type="button"
-                  key={gradient}
-                  className={`w-full h-11 rounded-md cursor-pointer transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 ${
-                    coverType === 'gradient' && coverValue === gradient
-                      ? 'ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-zinc-900'
-                      : ''
-                  }`}
-                  style={{ background: gradient }}
-                  onClick={() => {
-                    onChange('gradient', gradient);
-                    setOpened(false);
-                  }}
-                  aria-label="Select gradient"
-                />
-              ))}
-            </div>
-          </div>
+    <div ref={ref} className="relative inline-block">
+      <button
+        ref={targetRef}
+        type="button"
+        onClick={() => setOpened((o) => !o)}
+        className="cursor-pointer inline-block bg-transparent border-none p-0"
+      >
+        {children}
+      </button>
+      {opened && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpened(false)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') setOpened(false);
+            }}
+            aria-hidden="true"
+          />
+          <div
+            className="absolute z-50 animate-scale-in bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-4 rounded-lg shadow-xl"
+            style={{ minWidth: '20rem', top: '100%', left: 0, marginTop: '4px' }}
+          >
+            <div className="flex flex-col gap-4">
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300">Gradients</p>
+                  {(coverType || coverValue) && (
+                    <Tooltip label="Remove cover">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onChange(null, null);
+                          setOpened(false);
+                        }}
+                        className="cursor-pointer p-1 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
+                        aria-label="Remove cover"
+                      >
+                        <IconTrash size={14} />
+                      </button>
+                    </Tooltip>
+                  )}
+                </div>
+                <div className="grid grid-cols-4 gap-2">
+                  {GRADIENTS.map((gradient) => (
+                    <button
+                      type="button"
+                      key={gradient}
+                      className={`w-full h-11 rounded-md cursor-pointer transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 ${
+                        coverType === 'gradient' && coverValue === gradient
+                          ? 'ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-zinc-900'
+                          : ''
+                      }`}
+                      style={{ background: gradient }}
+                      onClick={() => {
+                        onChange('gradient', gradient);
+                        setOpened(false);
+                      }}
+                      aria-label="Select gradient"
+                    />
+                  ))}
+                </div>
+              </div>
 
-          <div>
-            <Text size="sm" fw={500} className="text-zinc-700 dark:text-zinc-300 mb-2">
-              Solid Colors
-            </Text>
-            <div className="grid grid-cols-6 gap-2">
-              {SOLID_COLORS.map((color) => (
-                <button
-                  type="button"
-                  key={color}
-                  className={`w-full h-9 rounded-md cursor-pointer transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 ${
-                    coverType === 'solid' && coverValue === color
-                      ? 'ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-zinc-900'
-                      : ''
-                  }`}
-                  style={{ backgroundColor: color }}
-                  onClick={() => {
-                    onChange('solid', color);
-                    setOpened(false);
-                  }}
-                  aria-label={`Select color ${color}`}
-                />
-              ))}
+              <div>
+                <p className="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-2">
+                  Solid Colors
+                </p>
+                <div className="grid grid-cols-6 gap-2">
+                  {SOLID_COLORS.map((color) => (
+                    <button
+                      type="button"
+                      key={color}
+                      className={`w-full h-9 rounded-md cursor-pointer transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-zinc-900 ${
+                        coverType === 'solid' && coverValue === color
+                          ? 'ring-2 ring-blue-500 ring-offset-2 dark:ring-offset-zinc-900'
+                          : ''
+                      }`}
+                      style={{ backgroundColor: color }}
+                      onClick={() => {
+                        onChange('solid', color);
+                        setOpened(false);
+                      }}
+                      aria-label={`Select color ${color}`}
+                    />
+                  ))}
+                </div>
+              </div>
             </div>
           </div>
-        </Stack>
-      </Popover.Dropdown>
-    </Popover>
+        </>
+      )}
+    </div>
   );
 }

--- a/packages/web/src/components/editor/editor.css
+++ b/packages/web/src/components/editor/editor.css
@@ -270,8 +270,8 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  background: var(--mantine-color-body, #fff);
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  background: #fff;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   padding: 8px 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -295,15 +295,15 @@
   cursor: pointer;
   font-size: 12px;
   font-weight: 500;
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  border: 1px solid #e4e4e7;
   background: transparent;
-  color: var(--mantine-color-text, #18181b);
+  color: #18181b;
   transition: background-color 0.15s;
 }
 
 .link-hover-tooltip-edit:hover,
 .link-hover-tooltip-remove:hover {
-  background: var(--mantine-color-gray-1, #f4f4f5);
+  background: #f4f4f5;
 }
 
 .dark .link-hover-tooltip {
@@ -330,8 +330,8 @@
 .link-editor-popup {
   position: absolute;
   z-index: 1000;
-  background: var(--mantine-color-body, #fff);
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  background: #fff;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   padding: 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -346,7 +346,7 @@
 .link-editor-header {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mantine-color-gray-6, #71717a);
+  color: #71717a;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -356,17 +356,17 @@
   padding: 10px 12px;
   font-size: 13px;
   line-height: 1.5;
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  border: 1px solid #e4e4e7;
   border-radius: 6px;
-  background: var(--mantine-color-input, #f4f4f5);
-  color: var(--mantine-color-text, #18181b);
+  background: #f4f4f5;
+  color: #18181b;
   outline: none;
   transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .link-editor-input:focus {
-  border-color: var(--mantine-color-blue-6, #2563eb);
-  box-shadow: 0 0 0 2px var(--mantine-color-blue-light, #dbeafe);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px #dbeafe;
 }
 
 .link-editor-buttons {
@@ -386,23 +386,23 @@
 
 .link-editor-btn-cancel {
   background: transparent;
-  color: var(--mantine-color-text, #18181b);
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  color: #18181b;
+  border: 1px solid #e4e4e7;
 }
 
 .link-editor-btn-cancel:hover {
-  background: var(--mantine-color-gray-1, #f4f4f5);
+  background: #f4f4f5;
 }
 
 .link-editor-btn-save {
-  background: var(--mantine-color-blue-6, #2563eb);
+  background: #2563eb;
   color: white;
   border: none;
   font-weight: 600;
 }
 
 .link-editor-btn-save:hover {
-  background: var(--mantine-color-blue-7, #1d4ed8);
+  background: #1d4ed8;
 }
 
 .link-editor-btn-remove {
@@ -617,7 +617,7 @@
 
 .math-editor-popup textarea:focus {
   outline: none;
-  border-color: var(--mantine-color-blue-filled);
+  border-color: #2563eb;
 }
 
 .math-editor-popup button {
@@ -651,46 +651,12 @@
   background: rgba(96, 165, 250, 0.1) !important;
 }
 
-/* Math Editor Popup Dark Mode Support */
-.dark .mantine-popup-area {
-  background: #18181b !important;
-  border-color: #27272a !important;
-}
-
-.dark .mantine-popup-area textarea {
-  background: #27272a !important;
-  color: #e4e4e7 !important;
-  border-color: #3f3f46 !important;
-}
-
-.dark .mantine-popup-area button:first-child {
-  background: transparent !important;
-  color: #e4e4e7 !important;
-  border-color: #3f3f46 !important;
-}
-
-.dark .mantine-popup-area button:first-child:hover {
-  background: #27272a !important;
-}
-
-.dark .mantine-popup-area button:last-child {
-  background: #2563eb !important;
-}
-
-.dark .mantine-popup-area button:last-child:hover {
-  background: #1d4ed8 !important;
-}
-
-.dark .mantine-popup-area button:active {
-  background: #1e40af !important;
-}
-
 /* MathEditor Component */
 .math-editor-popup {
   position: absolute;
   z-index: 1000;
-  background: var(--mantine-color-body, #fff);
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  background: #fff;
+  border: 1px solid #e4e4e7;
   border-radius: 8px;
   padding: 12px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
@@ -705,7 +671,7 @@
 .math-editor-header {
   font-size: 12px;
   font-weight: 600;
-  color: var(--mantine-color-gray-6, #71717a);
+  color: #71717a;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -716,19 +682,19 @@
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 13px;
   line-height: 1.5;
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  border: 1px solid #e4e4e7;
   border-radius: 6px;
   resize: vertical;
-  background: var(--mantine-color-input, #f4f4f5);
-  color: var(--mantine-color-text, #18181b);
+  background: #f4f4f5;
+  color: #18181b;
   outline: none;
   transition: border-color 0.2s, box-shadow 0.2s;
   min-width: 300px;
 }
 
 .math-editor-textarea:focus {
-  border-color: var(--mantine-color-blue-6, #2563eb);
-  box-shadow: 0 0 0 2px var(--mantine-color-blue-light, #dbeafe);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 2px #dbeafe;
 }
 
 .math-editor-buttons {
@@ -748,23 +714,23 @@
 
 .math-editor-btn-cancel {
   background: transparent;
-  color: var(--mantine-color-text, #18181b);
-  border: 1px solid var(--mantine-color-default-border, #e4e4e7);
+  color: #18181b;
+  border: 1px solid #e4e4e7;
 }
 
 .math-editor-btn-cancel:hover {
-  background: var(--mantine-color-gray-1, #f4f4f5);
+  background: #f4f4f5;
 }
 
 .math-editor-btn-done {
-  background: var(--mantine-color-blue-6, #2563eb);
+  background: #2563eb;
   color: white;
   border: none;
   font-weight: 600;
 }
 
 .math-editor-btn-done:hover {
-  background: var(--mantine-color-blue-7, #1d4ed8);
+  background: #1d4ed8;
 }
 
 .math-editor-btn-done:active {

--- a/packages/web/src/components/ui/popover.tsx
+++ b/packages/web/src/components/ui/popover.tsx
@@ -1,0 +1,45 @@
+import type React from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+
+interface PopoverProps {
+  opened: boolean;
+  onChange: (opened: boolean) => void;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Popover({ opened, onChange, children, className }: PopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = useCallback(
+    (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onChange(false);
+      }
+    },
+    [onChange],
+  );
+
+  const handleEscape = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onChange(false);
+      }
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (!opened) return;
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [opened, handleClickOutside, handleEscape]);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/packages/web/src/editor/plugins/math.ts
+++ b/packages/web/src/editor/plugins/math.ts
@@ -229,7 +229,7 @@ const latexCodeBlockView: NodeViewConstructor = (node, view, getPos) => {
   let currentNodeContent = node.content.firstChild?.text ?? '';
 
   dom.addEventListener('mouseenter', () => {
-    dom.style.background = 'var(--mantine-color-default-hover)';
+    dom.style.background = 'rgba(59, 130, 246, 0.08)';
   });
 
   dom.addEventListener('mouseleave', () => {

--- a/packages/web/src/hooks/useTheme.test.ts
+++ b/packages/web/src/hooks/useTheme.test.ts
@@ -71,7 +71,6 @@ describe('useTheme', () => {
     });
 
     expect(document.documentElement.classList.contains('dark')).toBe(true);
-    expect(document.documentElement.getAttribute('data-mantine-color-scheme')).toBe('dark');
   });
 
   it('removes "dark" class from documentElement when theme is light', () => {
@@ -83,7 +82,6 @@ describe('useTheme', () => {
     });
 
     expect(document.documentElement.classList.contains('dark')).toBe(false);
-    expect(document.documentElement.getAttribute('data-mantine-color-scheme')).toBe('light');
   });
 
   it('cycles through light -> dark -> system -> light', () => {

--- a/packages/web/src/hooks/useTheme.ts
+++ b/packages/web/src/hooks/useTheme.ts
@@ -39,10 +39,8 @@ export function useTheme() {
 
       if (dark) {
         root.classList.add('dark');
-        root.setAttribute('data-mantine-color-scheme', 'dark');
       } else {
         root.classList.remove('dark');
-        root.setAttribute('data-mantine-color-scheme', 'light');
       }
 
       localStorage.setItem('markdawn-theme', theme);

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,5 +1,3 @@
-import { MantineProvider, type MantineTheme, createTheme } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -7,11 +5,10 @@ import '@fontsource/inter/400.css';
 import '@fontsource/inter/500.css';
 import '@fontsource/inter/600.css';
 import '@fontsource/inter/700.css';
-import '@mantine/core/styles.css';
-import '@mantine/notifications/styles.css';
 import './index.css';
 import App from './App';
 import { getLogger, initLogger } from './logger-init';
+import { ToastProvider } from './utils/toast';
 
 initLogger()
   .then(() => {
@@ -25,81 +22,16 @@ initLogger()
     console.error('[app] failed to initialize logger:', err);
   });
 
-const theme = createTheme({
-  colors: {
-    success: [
-      '#fafafa',
-      '#f4f4f5',
-      '#e4e4e7',
-      '#d4d4d8',
-      '#a1a1aa',
-      '#71717a',
-      '#52525b',
-      '#3f3f46',
-      '#27272a',
-      '#18181b',
-    ],
-    error: [
-      '#fafafa',
-      '#f4f4f5',
-      '#e4e4e7',
-      '#d4d4d8',
-      '#a1a1aa',
-      '#71717a',
-      '#52525b',
-      '#3f3f46',
-      '#27272a',
-      '#18181b',
-    ],
-    info: [
-      '#fafafa',
-      '#f4f4f5',
-      '#e4e4e7',
-      '#d4d4d8',
-      '#a1a1aa',
-      '#71717a',
-      '#52525b',
-      '#3f3f46',
-      '#27272a',
-      '#18181b',
-    ],
-  },
-  primaryColor: 'success',
-  components: {
-    Notification: {
-      styles: (theme: MantineTheme) => ({
-        root: {
-          backgroundColor: 'var(--color-surface-elevated)',
-          border: '1px solid var(--color-border)',
-          color: 'var(--color-text)',
-          width: 'fit-content',
-          minWidth: '240px',
-          maxWidth: '420px',
-          marginLeft: 'auto',
-          marginRight: 'auto',
-        },
-        title: {
-          color: 'var(--color-text)',
-        },
-        description: {
-          color: 'var(--color-text-muted)',
-        },
-      }),
-    },
-  },
-});
-
 const queryClient = new QueryClient();
 
 const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Root element not found');
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
-    <MantineProvider theme={theme}>
-      <Notifications position="top-center" transitionDuration={300} />
+    <ToastProvider>
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
-    </MantineProvider>
+    </ToastProvider>
   </React.StrictMode>,
 );

--- a/packages/web/src/routes/PublicPage.tsx
+++ b/packages/web/src/routes/PublicPage.tsx
@@ -1,5 +1,5 @@
-import { Loader } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
 import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 
@@ -53,7 +53,7 @@ export default function PublicPage() {
           </Link>
         </header>
         <div className="flex-1 flex items-center justify-center">
-          <Loader color="gray" />
+          <Loader2 className="h-8 w-8 animate-spin text-zinc-400" />
         </div>
       </div>
     );

--- a/packages/web/src/test-utils/render.tsx
+++ b/packages/web/src/test-utils/render.tsx
@@ -1,30 +1,8 @@
-import { MantineProvider, createTheme } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type RenderOptions, type RenderResult, render as rtlRender } from '@testing-library/react';
 import type React from 'react';
 import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-
-const testTheme = createTheme({
-  components: {
-    Modal: {
-      defaultProps: {
-        transitionProps: { duration: 0 },
-      },
-    },
-    Drawer: {
-      defaultProps: {
-        transitionProps: { duration: 0 },
-      },
-    },
-    Popover: {
-      defaultProps: {
-        transitionProps: { duration: 0 },
-      },
-    },
-  },
-});
 
 export function createTestQueryClient(): QueryClient {
   return new QueryClient({
@@ -54,10 +32,7 @@ export function render(
   function Wrapper({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>
-        <MantineProvider theme={testTheme}>
-          <Notifications />
-          <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
-        </MantineProvider>
+        <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
       </QueryClientProvider>
     );
   }

--- a/packages/web/src/utils/toast.tsx
+++ b/packages/web/src/utils/toast.tsx
@@ -1,38 +1,72 @@
-import { notifications } from '@mantine/notifications';
 import { IconCheck, IconInfoCircle, IconX } from '@tabler/icons-react';
+import clsx from 'clsx';
+import type React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface Toast {
+  id: number;
+  message: string;
+  icon: React.ReactNode;
+  autoClose: number;
+}
+
+type AddToastFn = (toast: Omit<Toast, 'id'>) => void;
+
+let addToast: AddToastFn | null = null;
 
 export function showSuccessToast(message: string) {
-  notifications.show({
-    message,
-    color: 'gray',
-    icon: <IconCheck size={16} />,
-    autoClose: 4000,
-    withBorder: true,
-    withCloseButton: true,
-    className: 'animate-slide-down',
-  });
+  addToast?.({ message, icon: <IconCheck size={16} />, autoClose: 4000 });
 }
 
 export function showErrorToast(message: string) {
-  notifications.show({
-    message,
-    color: 'gray',
-    icon: <IconX size={16} />,
-    autoClose: 5000,
-    withBorder: true,
-    withCloseButton: true,
-    className: 'animate-slide-down',
-  });
+  addToast?.({ message, icon: <IconX size={16} />, autoClose: 5000 });
 }
 
 export function showInfoToast(message: string) {
-  notifications.show({
-    message,
-    color: 'gray',
-    icon: <IconInfoCircle size={16} />,
-    autoClose: 4000,
-    withBorder: true,
-    withCloseButton: true,
-    className: 'animate-slide-down',
-  });
+  addToast?.({ message, icon: <IconInfoCircle size={16} />, autoClose: 4000 });
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const nextId = useRef(0);
+
+  const add = useCallback((toast: Omit<Toast, 'id'>) => {
+    const id = nextId.current++;
+    setToasts((prev) => [...prev, { ...toast, id }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, toast.autoClose);
+  }, []);
+
+  useEffect(() => {
+    addToast = add;
+    return () => {
+      addToast = null;
+    };
+  }, [add]);
+
+  return (
+    <>
+      {children}
+      {createPortal(
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-[70] flex flex-col gap-2 pointer-events-none">
+          {toasts.map((toast) => (
+            <div
+              key={toast.id}
+              className={clsx(
+                'pointer-events-auto flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border animate-slide-down',
+                'bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-zinc-50',
+              )}
+              style={{ minWidth: '240px', maxWidth: '420px' }}
+            >
+              <span className="shrink-0 text-zinc-500 dark:text-zinc-400">{toast.icon}</span>
+              <span className="text-sm font-medium">{toast.message}</span>
+            </div>
+          ))}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -22,9 +22,7 @@ export default defineConfig(({ mode }) => {
               if (id.includes('yjs') || id.includes('@hocuspocus')) {
                 return 'collab';
               }
-              if (id.includes('@mantine')) {
-                return 'mantine';
-              }
+
               if (id.includes('react') || id.includes('react-dom')) {
                 return 'react';
               }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,15 +219,6 @@ importers:
       '@logtape/logtape':
         specifier: ^2.0.5
         version: 2.0.5
-      '@mantine/core':
-        specifier: ^8.3.15
-        version: 8.3.15(@mantine/hooks@8.3.15(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks':
-        specifier: ^8.3.15
-        version: 8.3.15(react@19.2.4)
-      '@mantine/notifications':
-        specifier: ^8.3.15
-        version: 8.3.15(@mantine/core@8.3.15(@mantine/hooks@8.3.15(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.15(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@markdawn/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1104,18 +1095,6 @@ packages:
   '@floating-ui/dom@1.7.5':
     resolution: {integrity: sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==}
 
-  '@floating-ui/react-dom@2.1.7':
-    resolution: {integrity: sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/react@0.27.18':
-    resolution: {integrity: sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==}
-    peerDependencies:
-      react: '>=17.0.0'
-      react-dom: '>=17.0.0'
-
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
@@ -1191,31 +1170,6 @@ packages:
 
   '@logtape/logtape@2.0.5':
     resolution: {integrity: sha512-UizDkh20ZPJVOddRxG1F77WhHdlNl/sbQgoO8T534R7XvUBMAJ9En9f35u+meW2tRsNLvjz6R87Zanwf53tspQ==}
-
-  '@mantine/core@8.3.15':
-    resolution: {integrity: sha512-wBn/GogB4x7a2Uj7Ztt3amRaApjED+9XqfE4wyCLh88R7KV55k9vnTdCx+irI/GLOOu9tXNUGm3a4t5sTajwkQ==}
-    peerDependencies:
-      '@mantine/hooks': 8.3.15
-      react: ^18.x || ^19.x
-      react-dom: ^18.x || ^19.x
-
-  '@mantine/hooks@8.3.15':
-    resolution: {integrity: sha512-AUSnpUlzttHzJht3CJ1YWi16iy6NWRwtyWO5RLGHHsmiW05DyG0qOPKF8+R5dLHuOCnl3XOu4roI2Y1ku9U04Q==}
-    peerDependencies:
-      react: ^18.x || ^19.x
-
-  '@mantine/notifications@8.3.15':
-    resolution: {integrity: sha512-CJGSv8oeLWyJIVPninU7Ud6vV6/UJKWZJwRGBNg2K0Ak0U0coFN3gW3H6G1Mh2zllNxb3K4fpMJNz4Iy0sCBFw==}
-    peerDependencies:
-      '@mantine/core': 8.3.15
-      '@mantine/hooks': 8.3.15
-      react: ^18.x || ^19.x
-      react-dom: ^18.x || ^19.x
-
-  '@mantine/store@8.3.15':
-    resolution: {integrity: sha512-wdx91a73dM2G02YPIZ9i5UXPWfvjdf3qPAwSGnSsBFQg5uM/5CcPAOOQwlYIkvX1edUA5BFOk/4IjpEXSYUDeQ==}
-    peerDependencies:
-      react: ^18.x || ^19.x
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
@@ -1989,9 +1943,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -2004,9 +1955,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  dom-helpers@5.2.1:
-    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dompurify@3.4.0:
     resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
@@ -2202,10 +2150,6 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
-
-  get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
@@ -2431,10 +2375,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -2762,9 +2702,6 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   prosemirror-changeset@2.4.0:
     resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
 
@@ -2819,44 +2756,15 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-number-format@5.4.4:
-    resolution: {integrity: sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==}
-    peerDependencies:
-      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
-
-  react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   react-router-dom@7.13.0:
     resolution: {integrity: sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==}
@@ -2874,28 +2782,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-textarea-autosize@8.5.9:
-    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  react-transition-group@4.4.5:
-    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
-    peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -3027,9 +2913,6 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tabbable@6.4.0:
-    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
   tailwindcss@4.2.0:
     resolution: {integrity: sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==}
 
@@ -3114,10 +2997,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3159,53 +3038,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-composed-ref@1.4.0:
-    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-isomorphic-layout-effect@1.2.1:
-    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-latest@1.3.0:
-    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3904,20 +3736,6 @@ snapshots:
       '@floating-ui/core': 1.7.4
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@floating-ui/dom': 1.7.5
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@floating-ui/react@0.27.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@floating-ui/utils': 0.2.10
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      tabbable: 6.4.0
-
   '@floating-ui/utils@0.2.10': {}
 
   '@fontsource/inter@5.2.8': {}
@@ -4015,37 +3833,6 @@ snapshots:
       hono: 4.12.0
 
   '@logtape/logtape@2.0.5': {}
-
-  '@mantine/core@8.3.15(@mantine/hooks@8.3.15(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@floating-ui/react': 0.27.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.15(react@19.2.4)
-      clsx: 2.1.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-number-format: 5.4.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
-      react-textarea-autosize: 8.5.9(@types/react@19.2.14)(react@19.2.4)
-      type-fest: 4.41.0
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mantine/hooks@8.3.15(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
-
-  '@mantine/notifications@8.3.15(@mantine/core@8.3.15(@mantine/hooks@8.3.15(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@mantine/hooks@8.3.15(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@mantine/core': 8.3.15(@mantine/hooks@8.3.15(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@mantine/hooks': 8.3.15(react@19.2.4)
-      '@mantine/store': 8.3.15(react@19.2.4)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-
-  '@mantine/store@8.3.15(react@19.2.4)':
-    dependencies:
-      react: 19.2.4
 
   '@marijn/find-cluster-break@1.0.2': {}
 
@@ -4881,8 +4668,6 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-node-es@1.1.0: {}
-
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -4892,11 +4677,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  dom-helpers@5.2.1:
-    dependencies:
-      '@babel/runtime': 7.28.6
-      csstype: 3.2.3
 
   dompurify@3.4.0:
     optionalDependencies:
@@ -5057,8 +4837,6 @@ snapshots:
   fuse.js@7.3.0: {}
 
   gensync@1.0.0-beta.2: {}
-
-  get-nonce@1.0.1: {}
 
   get-tsconfig@4.13.6:
     dependencies:
@@ -5251,10 +5029,6 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   lru-cache@11.3.5: {}
 
@@ -5749,12 +5523,6 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   prosemirror-changeset@2.4.0:
     dependencies:
       prosemirror-transform: 1.11.0
@@ -5848,37 +5616,11 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-is@16.13.1: {}
-
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
-  react-number-format@5.4.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   react-refresh@0.18.0: {}
-
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
-      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
-      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   react-router-dom@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -5892,32 +5634,6 @@ snapshots:
       react: 19.2.4
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.4(react@19.2.4)
-
-  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.2.4
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  react-textarea-autosize@8.5.9(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      react: 19.2.4
-      use-composed-ref: 1.4.0(@types/react@19.2.14)(react@19.2.4)
-      use-latest: 1.3.0(@types/react@19.2.14)(react@19.2.4)
-    transitivePeerDependencies:
-      - '@types/react'
-
-  react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      dom-helpers: 5.2.1
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
@@ -6091,8 +5807,6 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tabbable@6.4.0: {}
-
   tailwindcss@4.2.0: {}
 
   tapable@2.3.0: {}
@@ -6175,8 +5889,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  type-fest@4.41.0: {}
-
   typescript@5.9.3: {}
 
   ufo@1.6.3: {}
@@ -6226,40 +5938,6 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  use-composed-ref@1.4.0(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  use-latest@1.3.0(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.14)(react@19.2.4)
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.2.4
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.14
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

Replaces all Mantine UI components (`@mantine/core`, `@mantine/notifications`, `@mantine/hooks`) with lightweight custom implementations using Tailwind CSS and lucide-react. Reduces dependencies, bundle size, and build complexity.

## Changes

### Removed dependencies
- `@mantine/core` ^8.3.15
- `@mantine/hooks` ^8.3.15  
- `@mantine/notifications` ^8.3.15

### New components
- **Toast system** (`src/utils/toast.tsx`) — `ToastProvider` + `showSuccessToast`/`showErrorToast`/`showInfoToast` helpers. Same API as before, zero breakage across 7 callers.
- **Popover** (`src/components/ui/popover.tsx`) — Lightweight popover with click-outside-to-close and Escape dismissal.

### Components rewritten without Mantine
| File | Replaced Mantine imports |
|---|---|
| `CoverPicker.tsx` | `ActionIcon`, `Button`, `Group`, `Popover`, `Stack`, `Text`, `Tooltip` |
| `EmojiPicker.tsx` | `Popover` |
| `PublicPage.tsx` | `Loader` → lucide-react `Loader2` |
| `main.tsx` | `MantineProvider`, `Notifications`, `createTheme`, CSS imports |
| `test-utils/render.tsx` | `MantineProvider`, `Notifications`, `createTheme` |

### CSS cleanup
- Replaced all 10 `--mantine-color-*` CSS variable patterns with hardcoded fallback values in `editor.css`
- Removed `.mantine-popup-area` dark mode selectors
- Replaced `--mantine-color-default-hover` in `math.ts` with inline `rgba()`
- Stopped setting `data-mantine-color-scheme` attribute in `useTheme.ts`

### Config
- Dropped the `mantine` vendor chunk from Vite rollup config

## Verification
- TypeScript: `tsc --noEmit` passes
- Unit tests: 144/144 pass across 22 files
- All E2E tests unaffected (none used Mantine-specific selectors)

## Commits
1. `refactor(web): replace mantine notifications with custom toast system`
2. `refactor(web): replace mantine popover with custom component`
3. `refactor(web): replace mantine components in cover picker with tailwind`
4. `refactor(web): replace mantine css variables and loader with plain css`
5. `fix(web): stop setting mantine color-scheme attribute on theme change`
6. `chore(deps): remove mantine dependencies`