### PR TITLE
fix(editor): slash menu whitespace edge cases and viewport scroll bug

### DIFF
--- a/e2e/editor/slash-menu.spec.ts
+++ b/e2e/editor/slash-menu.spec.ts
@@ -257,4 +257,60 @@ test.describe('Slash menu', () => {
       });
     });
   });
+
+  test.describe('Whitespace edge cases', () => {
+    test('does not open when / is followed by a space', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/ ');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('closes slash menu when space is typed after a query', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/h1');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.type(' ');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('does not open when / appears mid-paragraph with surrounding spaces', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('rolling distribution has no / or after some interval');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('does not open for slash in a URL-like string', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('Check out https://example.com/page for details');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('closes menu when typing continues with space after slash command', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/h1');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.type(' more');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+    });
+
+    test('can still trigger slash menu after dismissing from whitespace', async ({ page }) => {
+      await createNewPage(page);
+      await focusEditor(page);
+      await page.keyboard.type('/ ');
+      await expect(page.locator('[data-testid="slash-menu"]')).not.toBeVisible({ timeout: 2000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('/h2');
+      await expect(page.locator('[data-testid="slash-menu"]')).toBeVisible({ timeout: 5000 });
+      await page.keyboard.press('Enter');
+      await page.keyboard.type('Still works');
+      await expect(page.locator('.ProseMirror h2')).toContainText('Still works', {
+        timeout: 5000,
+      });
+    });
+  });
 });

--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -1,26 +1,8 @@
-import {
-  IconBlockquote,
-  IconBold,
-  IconCode,
-  IconH1,
-  IconH2,
-  IconH3,
-  IconH4,
-  IconH5,
-  IconH6,
-  IconItalic,
-  IconLink,
-  IconList,
-  IconListCheck,
-  IconListNumbers,
-  IconPhoto,
-  IconStrikethrough,
-  IconTable,
-} from '@tabler/icons-react';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAwareness } from '../../hooks/useAwareness';
 import { useFloatingToolbar } from '../../hooks/useFloatingToolbar';
 import { useMilkdown } from '../../hooks/useMilkdown';
+import { useSlashMenu } from '../../hooks/useSlashMenu';
 import { useWikiLinkSuggestions } from '../../hooks/useWikiLinkSuggestions';
 import { authClient } from '../../lib/auth-client';
 import { getLogger } from '../../logger-init';
@@ -176,29 +158,6 @@ export function MilkdownEditor({
     closeSuggestions,
   } = useWikiLinkSuggestions(workspaceId, editorRef);
 
-  const [slashMenuState, setSlashMenuState] = useState({
-    isOpen: false,
-    query: '',
-    position: null as { x: number; y: number; top?: number; bottom?: number } | null,
-    range: null as { from: number; to: number } | null,
-  });
-
-  const handleSlashMenuSuggest = useCallback(
-    (
-      isOpen: boolean,
-      query: string,
-      position: { x: number; y: number; top?: number; bottom?: number } | null,
-      range: { from: number; to: number } | null,
-    ) => {
-      setSlashMenuState({ isOpen, query, position, range });
-    },
-    [],
-  );
-
-  const closeSlashMenu = useCallback(() => {
-    setSlashMenuState((prev) => ({ ...prev, isOpen: false }));
-  }, []);
-
   const [activeStates, setActiveStates] = useState({
     isBoldActive: false,
     isItalicActive: false,
@@ -339,6 +298,15 @@ export function MilkdownEditor({
     });
   }, [pageId, doc]);
 
+  const handleSlashMenuSuggestRef = useRef<
+    (
+      isOpen: boolean,
+      query: string,
+      position: { x: number; y: number; top?: number; bottom?: number } | null,
+      range: { from: number; to: number } | null,
+    ) => void
+  >(() => {});
+
   const { setContainer, editor } = useMilkdown({
     ...(initialValue !== undefined && { initialValue }),
     ...(onChange !== undefined && { onChange }),
@@ -346,7 +314,9 @@ export function MilkdownEditor({
     provider,
     onWikiLinkClick,
     onWikiLinkSuggest: handleWikiLinkSuggest,
-    onSlashMenuSuggest: handleSlashMenuSuggest,
+    onSlashMenuSuggest: useCallback((isOpen, query, position, range) => {
+      handleSlashMenuSuggestRef.current(isOpen, query, position, range);
+    }, []),
   });
 
   useAwareness(provider);
@@ -515,346 +485,6 @@ export function MilkdownEditor({
     });
   };
 
-  // Slash-specific handlers that don't call keepVisible()
-  const handleSlashParagraph = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const paraType = state.schema.nodes.paragraph;
-      if (!paraType) return;
-      const command = setBlockType(paraType as never);
-      command(state, dispatch);
-    });
-  };
-
-  const handleSlashHeading = (level: number) => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const headingType = state.schema.nodes.heading;
-      if (!headingType) return;
-      const command = setBlockType(headingType as never, { level });
-      command(state, dispatch);
-    });
-  };
-
-  const handleSlashQuote = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const blockquoteType = state.schema.nodes.blockquote;
-      if (!blockquoteType) return;
-      const command = wrapIn(blockquoteType as never);
-      command(state, dispatch);
-    });
-  };
-
-  const handleSlashBulletList = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const bulletListType = state.schema.nodes.bullet_list;
-      if (!bulletListType) return;
-      const command = wrapIn(bulletListType as never);
-      command(state, dispatch);
-    });
-  };
-
-  const handleSlashOrderedList = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const orderedListType = state.schema.nodes.ordered_list;
-      if (!orderedListType) return;
-      const command = wrapIn(orderedListType as never);
-      command(state, dispatch);
-    });
-  };
-
-  const handleSlashTaskList = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const bulletListType = state.schema.nodes.bullet_list;
-      const listItemType = state.schema.nodes.list_item;
-      if (!bulletListType || !listItemType) return;
-
-      const command = wrapIn(bulletListType as never);
-      command(state, dispatch);
-
-      const newState = view.state;
-      const tr = newState.tr;
-      const { from, to } = newState.selection;
-      newState.doc.nodesBetween(from, to, (node, pos) => {
-        if (node.type === listItemType && node.attrs.checked == null) {
-          tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked: false });
-        }
-      });
-      if (tr.docChanged) {
-        dispatch(tr);
-      }
-    });
-  };
-
-  const handleSlashInsertTable = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const commands = ctx.get(commandsCtx);
-      commands.call(insertTableCommand.key, { row: 3, col: 3 });
-    });
-  };
-
-  const handleSlashDivider = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const hrType = state.schema.nodes.hr;
-      if (!hrType) return;
-      const { $from } = state.selection;
-      const node = hrType.create();
-      const tr = state.tr.insert($from.pos, node);
-      dispatch(tr);
-    });
-  };
-
-  const handleSlashTag = () => {
-    if (!editor) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const { $from } = state.selection;
-      const tr = state.tr.insertText('#tag ', $from.pos);
-      dispatch(tr);
-    });
-  };
-
-  const removeSlashTrigger = () => {
-    const range = slashMenuState.range;
-    if (!editor || !range) return;
-    editor.action((ctx) => {
-      const view = ctx.get(editorViewCtx);
-      if (!view) return;
-      const { state, dispatch } = view;
-      const { from, to } = range;
-      const tr = state.tr.delete(from, to);
-      const cursorPos = from;
-      tr.setSelection(TextSelection.near(tr.doc.resolve(cursorPos)));
-      dispatch(tr);
-    });
-  };
-
-  const executeSlashAction = (action: () => void) => {
-    removeSlashTrigger();
-    closeSlashMenu();
-    setTimeout(() => {
-      action();
-      if (editor) {
-        editor.action((ctx) => {
-          const view = ctx.get(editorViewCtx);
-          if (view) {
-            view.focus();
-          }
-        });
-      }
-    }, 0);
-  };
-
-  const slashCommands = [
-    {
-      id: 'paragraph',
-      label: 'Paragraph',
-      hint: 'P',
-      shortcut: 'Ctrl+Alt+0',
-      keywords: ['paragraph', 'text', 'p'],
-      icon: <span className="text-xs">¶</span>,
-      onSelect: () => executeSlashAction(handleSlashParagraph),
-    },
-    {
-      id: 'h1',
-      label: 'Heading 1',
-      hint: 'H1',
-      shortcut: 'Ctrl+Alt+1',
-      keywords: ['heading', 'h1', 'title'],
-      icon: <IconH1 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(1)),
-    },
-    {
-      id: 'h2',
-      label: 'Heading 2',
-      hint: 'H2',
-      shortcut: 'Ctrl+Alt+2',
-      keywords: ['heading', 'h2'],
-      icon: <IconH2 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(2)),
-    },
-    {
-      id: 'h3',
-      label: 'Heading 3',
-      hint: 'H3',
-      shortcut: 'Ctrl+Alt+3',
-      keywords: ['heading', 'h3'],
-      icon: <IconH3 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(3)),
-    },
-    {
-      id: 'h4',
-      label: 'Heading 4',
-      hint: 'H4',
-      shortcut: 'Ctrl+Alt+4',
-      keywords: ['heading', 'h4'],
-      icon: <IconH4 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(4)),
-    },
-    {
-      id: 'h5',
-      label: 'Heading 5',
-      hint: 'H5',
-      shortcut: 'Ctrl+Alt+5',
-      keywords: ['heading', 'h5'],
-      icon: <IconH5 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(5)),
-    },
-    {
-      id: 'h6',
-      label: 'Heading 6',
-      hint: 'H6',
-      shortcut: 'Ctrl+Alt+6',
-      keywords: ['heading', 'h6'],
-      icon: <IconH6 size={16} />,
-      onSelect: () => executeSlashAction(() => handleSlashHeading(6)),
-    },
-    {
-      id: 'bold',
-      label: 'Bold',
-      hint: 'Bold',
-      shortcut: 'Ctrl+B',
-      keywords: ['bold', 'strong'],
-      icon: <IconBold size={16} />,
-      onSelect: () => executeSlashAction(handleBold),
-    },
-    {
-      id: 'italic',
-      label: 'Italic',
-      hint: 'Italic',
-      shortcut: 'Ctrl+I',
-      keywords: ['italic', 'emphasis'],
-      icon: <IconItalic size={16} />,
-      onSelect: () => executeSlashAction(handleItalic),
-    },
-    {
-      id: 'strikethrough',
-      label: 'Strikethrough',
-      hint: 'Strike',
-      shortcut: 'Ctrl+Shift+X',
-      keywords: ['strikethrough', 'strike'],
-      icon: <IconStrikethrough size={16} />,
-      onSelect: () => executeSlashAction(handleStrike),
-    },
-    {
-      id: 'code',
-      label: 'Code',
-      hint: 'Code',
-      shortcut: 'Ctrl+`',
-      keywords: ['code', 'inline'],
-      icon: <IconCode size={16} />,
-      onSelect: () => executeSlashAction(handleCode),
-    },
-    {
-      id: 'blockquote',
-      label: 'Blockquote',
-      hint: 'Quote',
-      shortcut: 'Ctrl+Shift+>',
-      keywords: ['quote', 'blockquote', 'citation'],
-      icon: <IconBlockquote size={16} />,
-      onSelect: () => executeSlashAction(handleSlashQuote),
-    },
-    {
-      id: 'link',
-      label: 'Link',
-      hint: 'Link',
-      shortcut: 'Ctrl+K',
-      keywords: ['link', 'url'],
-      icon: <IconLink size={16} />,
-      onSelect: () => executeSlashAction(handleLink),
-    },
-    {
-      id: 'bullet-list',
-      label: 'Bullet List',
-      hint: 'Bullet',
-      shortcut: 'Ctrl+Shift+8',
-      keywords: ['bullet', 'list', 'unordered'],
-      icon: <IconList size={16} />,
-      onSelect: () => executeSlashAction(handleSlashBulletList),
-    },
-    {
-      id: 'ordered-list',
-      label: 'Ordered List',
-      hint: 'Ordered',
-      shortcut: 'Ctrl+Shift+7',
-      keywords: ['ordered', 'list', 'number', 'numbered'],
-      icon: <IconListNumbers size={16} />,
-      onSelect: () => executeSlashAction(handleSlashOrderedList),
-    },
-    {
-      id: 'task-list',
-      label: 'Task List',
-      hint: 'Check',
-      shortcut: 'Ctrl+Shift+[',
-      keywords: ['task', 'check', 'list', 'todo', 'checkbox'],
-      icon: <IconListCheck size={16} />,
-      onSelect: () => executeSlashAction(handleSlashTaskList),
-    },
-    {
-      id: 'table',
-      label: 'Table',
-      hint: 'Table',
-      keywords: ['table', 'grid'],
-      icon: <IconTable size={16} />,
-      onSelect: () => executeSlashAction(handleSlashInsertTable),
-    },
-    {
-      id: 'image',
-      label: 'Image',
-      hint: 'Img',
-      shortcut: 'Ctrl+Shift+I',
-      keywords: ['image', 'photo', 'upload'],
-      icon: <IconPhoto size={16} />,
-      onSelect: () => executeSlashAction(handleImageUploadFromSlash),
-    },
-    {
-      id: 'divider',
-      label: 'Divider',
-      hint: 'Line',
-      keywords: ['divider', 'hr', 'line', 'separator', 'horizontal rule'],
-      icon: <span className="text-lg">—</span>,
-      onSelect: () => executeSlashAction(handleSlashDivider),
-    },
-    {
-      id: 'tag',
-      label: 'Tag',
-      hint: 'Tag',
-      shortcut: 'Ctrl+Shift+#',
-      keywords: ['tag', 'label', 'property', '#'],
-      icon: <span className="text-sm">#</span>,
-      onSelect: () => executeSlashAction(handleSlashTag),
-    },
-  ];
-
   const handleBold = () => {
     runMarkCommand('strong');
     setTimeout(updateActiveStates, 0);
@@ -969,6 +599,21 @@ export function MilkdownEditor({
     };
     input.click();
   };
+
+  const { slashMenuState, handleSlashMenuSuggest, closeSlashMenu, slashCommands } = useSlashMenu(
+    editorRef,
+    {
+      handleBold,
+      handleItalic,
+      handleStrike,
+      handleCode,
+      handleLink,
+      handleImageUploadFromSlash,
+    },
+  );
+
+  handleSlashMenuSuggestRef.current = handleSlashMenuSuggest;
+
   const handleH1 = () => {
     runBlockCommand('heading', { level: 1 });
     setTimeout(updateActiveStates, 0);

--- a/packages/web/src/components/editor/SlashMenu.tsx
+++ b/packages/web/src/components/editor/SlashMenu.tsx
@@ -25,11 +25,8 @@ const MENU_OVERFLOW_THRESHOLD = 320;
 
 export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashMenuProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({
-    opacity: 0,
-    pointerEvents: 'none',
-  });
   const [placement, setPlacement] = useState<'top' | 'bottom'>('bottom');
   const trimmedQuery = query.trim();
 
@@ -56,16 +53,16 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
   }, [results]);
 
   useLayoutEffect(() => {
-    if (!isOpen || !position || !containerRef.current) {
-      if (!isOpen) {
-        setMenuStyle({ opacity: 0, pointerEvents: 'none' });
-      }
+    const el = containerRef.current;
+    if (!el) return;
+    if (!isOpen || !position) {
+      el.style.opacity = '0';
+      el.style.pointerEvents = 'none';
       return;
     }
 
     const viewportHeight = window.innerHeight;
     const viewportWidth = window.innerWidth;
-    const x = position.x;
     const bottomCoord = position.bottom ?? position.y;
     const topCoord = position.top ?? position.y - 20;
     const nextPlacement =
@@ -73,30 +70,38 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
 
     setPlacement(nextPlacement);
 
-    const style: React.CSSProperties = {
-      position: 'fixed',
-      left: Math.max(20, Math.min(x, viewportWidth - MENU_WIDTH - 20)),
-      opacity: 1,
-      pointerEvents: 'auto',
-      zIndex: 100,
-    };
+    el.style.position = 'fixed';
+    el.style.left = `${Math.max(20, Math.min(position.x, viewportWidth - MENU_WIDTH - 20))}px`;
+    el.style.opacity = '1';
+    el.style.pointerEvents = 'auto';
+    el.style.zIndex = '100';
 
     if (nextPlacement === 'top') {
-      style.bottom = viewportHeight - topCoord + 8;
+      el.style.top = 'auto';
+      el.style.bottom = `${viewportHeight - topCoord + 8}px`;
     } else {
-      style.top = bottomCoord + 4;
+      el.style.top = `${bottomCoord + 4}px`;
+      el.style.bottom = 'auto';
     }
-
-    setMenuStyle(style);
   }, [isOpen, position]);
 
   useEffect(() => {
     if (!isOpen) return;
 
-    const buttons = containerRef.current?.querySelectorAll<HTMLElement>(':scope button');
-    const selectedElement = buttons?.[selectedIndex];
-    if (selectedElement) {
-      selectedElement.scrollIntoView({ block: 'nearest' });
+    const list = listRef.current;
+    if (!list) return;
+
+    const buttons = list.querySelectorAll<HTMLElement>(':scope > button');
+    const selectedButton = buttons[selectedIndex];
+    if (!selectedButton) return;
+
+    const listRect = list.getBoundingClientRect();
+    const buttonRect = selectedButton.getBoundingClientRect();
+
+    if (buttonRect.bottom > listRect.bottom) {
+      list.scrollTop += buttonRect.bottom - listRect.bottom;
+    } else if (buttonRect.top < listRect.top) {
+      list.scrollTop -= listRect.top - buttonRect.top;
     }
   }, [selectedIndex, isOpen]);
 
@@ -163,13 +168,15 @@ export function SlashMenu({ isOpen, query, position, commands, onClose }: SlashM
           ? 'zoom-in-95 slide-in-from-top-2'
           : 'zoom-in-95 slide-in-from-bottom-2'
       } bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-900 dark:text-zinc-100`}
-      style={menuStyle}
     >
       <div className="px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-500 border-b border-zinc-100 dark:border-zinc-800/50">
         Insert block
       </div>
 
-      <div className="max-h-[300px] overflow-y-auto p-1.5 space-y-0.5 scrollbar-thin scrollbar-thumb-zinc-200 dark:scrollbar-thumb-zinc-800">
+      <div
+        ref={listRef}
+        className="max-h-[300px] overflow-y-auto p-1.5 space-y-0.5 scrollbar-thin scrollbar-thumb-zinc-200 dark:scrollbar-thumb-zinc-800"
+      >
         {results.length === 0 ? (
           <div className="px-3 py-4 text-center text-sm text-zinc-500">No matching commands</div>
         ) : (

--- a/packages/web/src/hooks/useMilkdown.ts
+++ b/packages/web/src/hooks/useMilkdown.ts
@@ -378,6 +378,12 @@ export function useMilkdown({
               }
 
               const query = textBefore.slice(slashIndex + 1);
+
+              if (query && /\s/.test(query)) {
+                suggestSlash(false, '', null, null);
+                return;
+              }
+
               const coords = view.coordsAtPos($from.pos);
               const slashFrom = $from.start() + slashIndex;
               suggestSlash(

--- a/packages/web/src/hooks/useSlashMenu.ts
+++ b/packages/web/src/hooks/useSlashMenu.ts
@@ -1,0 +1,436 @@
+import { commandsCtx, editorViewCtx } from '@milkdown/core';
+import type { Editor } from '@milkdown/core';
+import { insertTableCommand } from '@milkdown/preset-gfm';
+import {
+  IconBlockquote,
+  IconBold,
+  IconCode,
+  IconH1,
+  IconH2,
+  IconH3,
+  IconH4,
+  IconH5,
+  IconH6,
+  IconItalic,
+  IconLink,
+  IconList,
+  IconListCheck,
+  IconListNumbers,
+  IconPhoto,
+  IconStrikethrough,
+  IconTable,
+} from '@tabler/icons-react';
+import { setBlockType, wrapIn } from 'prosemirror-commands';
+import { TextSelection } from 'prosemirror-state';
+import { type MutableRefObject, createElement, useCallback, useRef, useState } from 'react';
+
+interface SlashMenuState {
+  isOpen: boolean;
+  query: string;
+  position: { x: number; y: number; top?: number; bottom?: number } | null;
+  range: { from: number; to: number } | null;
+}
+
+interface UseSlashMenuOptions {
+  handleBold: () => void;
+  handleItalic: () => void;
+  handleStrike: () => void;
+  handleCode: () => void;
+  handleLink: () => void;
+  handleImageUploadFromSlash: () => void;
+}
+
+export function useSlashMenu(
+  editorRef: MutableRefObject<Editor | null>,
+  {
+    handleBold,
+    handleItalic,
+    handleStrike,
+    handleCode,
+    handleLink,
+    handleImageUploadFromSlash,
+  }: UseSlashMenuOptions,
+) {
+  const [slashMenuState, setSlashMenuState] = useState<SlashMenuState>({
+    isOpen: false,
+    query: '',
+    position: null,
+    range: null,
+  });
+
+  const rangeRef = useRef(slashMenuState.range);
+  rangeRef.current = slashMenuState.range;
+
+  const handleSlashMenuSuggest = useCallback(
+    (
+      isOpen: boolean,
+      query: string,
+      position: { x: number; y: number; top?: number; bottom?: number } | null,
+      range: { from: number; to: number } | null,
+    ) => {
+      setSlashMenuState({ isOpen, query, position, range });
+    },
+    [],
+  );
+
+  const closeSlashMenu = useCallback(() => {
+    setSlashMenuState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const handleSlashParagraph = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const paraType = state.schema.nodes.paragraph;
+      if (!paraType) return;
+      const command = setBlockType(paraType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashHeading = (level: number) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const headingType = state.schema.nodes.heading;
+      if (!headingType) return;
+      const command = setBlockType(headingType as never, { level });
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashQuote = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const blockquoteType = state.schema.nodes.blockquote;
+      if (!blockquoteType) return;
+      const command = wrapIn(blockquoteType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashBulletList = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const bulletListType = state.schema.nodes.bullet_list;
+      if (!bulletListType) return;
+      const command = wrapIn(bulletListType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashOrderedList = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const orderedListType = state.schema.nodes.ordered_list;
+      if (!orderedListType) return;
+      const command = wrapIn(orderedListType as never);
+      command(state, dispatch);
+    });
+  };
+
+  const handleSlashTaskList = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const bulletListType = state.schema.nodes.bullet_list;
+      const listItemType = state.schema.nodes.list_item;
+      if (!bulletListType || !listItemType) return;
+
+      const command = wrapIn(bulletListType as never);
+      command(state, dispatch);
+
+      const newState = view.state;
+      const tr = newState.tr;
+      const { from, to } = newState.selection;
+      newState.doc.nodesBetween(from, to, (node, pos) => {
+        if (node.type === listItemType && node.attrs.checked == null) {
+          tr.setNodeMarkup(pos, undefined, { ...node.attrs, checked: false });
+        }
+      });
+      if (tr.docChanged) {
+        dispatch(tr);
+      }
+    });
+  };
+
+  const handleSlashInsertTable = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const commands = ctx.get(commandsCtx);
+      commands.call(insertTableCommand.key, { row: 3, col: 3 });
+    });
+  };
+
+  const handleSlashDivider = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const hrType = state.schema.nodes.hr;
+      if (!hrType) return;
+      const { $from } = state.selection;
+      const node = hrType.create();
+      const tr = state.tr.insert($from.pos, node);
+      dispatch(tr);
+    });
+  };
+
+  const handleSlashTag = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const { $from } = state.selection;
+      const tr = state.tr.insertText('#tag ', $from.pos);
+      dispatch(tr);
+    });
+  };
+
+  const removeSlashTrigger = () => {
+    const range = rangeRef.current;
+    const editor = editorRef.current;
+    if (!editor || !range) return;
+    editor.action((ctx) => {
+      const view = ctx.get(editorViewCtx);
+      if (!view) return;
+      const { state, dispatch } = view;
+      const { from, to } = range;
+      const tr = state.tr.delete(from, to);
+      const cursorPos = from;
+      tr.setSelection(TextSelection.near(tr.doc.resolve(cursorPos)));
+      dispatch(tr);
+    });
+  };
+
+  const executeSlashAction = (action: () => void) => {
+    removeSlashTrigger();
+    closeSlashMenu();
+    setTimeout(() => {
+      action();
+      const editor = editorRef.current;
+      if (editor) {
+        editor.action((ctx) => {
+          const view = ctx.get(editorViewCtx);
+          if (view) {
+            view.focus();
+          }
+        });
+      }
+    }, 0);
+  };
+
+  const slashCommands = [
+    {
+      id: 'paragraph',
+      label: 'Paragraph',
+      hint: 'P',
+      shortcut: 'Ctrl+Alt+0',
+      keywords: ['paragraph', 'text', 'p'],
+      icon: createElement('span', { className: 'text-xs' }, '\u00B6'),
+      onSelect: () => executeSlashAction(handleSlashParagraph),
+    },
+    {
+      id: 'h1',
+      label: 'Heading 1',
+      hint: 'H1',
+      shortcut: 'Ctrl+Alt+1',
+      keywords: ['heading', 'h1', 'title'],
+      icon: createElement(IconH1, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(1)),
+    },
+    {
+      id: 'h2',
+      label: 'Heading 2',
+      hint: 'H2',
+      shortcut: 'Ctrl+Alt+2',
+      keywords: ['heading', 'h2'],
+      icon: createElement(IconH2, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(2)),
+    },
+    {
+      id: 'h3',
+      label: 'Heading 3',
+      hint: 'H3',
+      shortcut: 'Ctrl+Alt+3',
+      keywords: ['heading', 'h3'],
+      icon: createElement(IconH3, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(3)),
+    },
+    {
+      id: 'h4',
+      label: 'Heading 4',
+      hint: 'H4',
+      shortcut: 'Ctrl+Alt+4',
+      keywords: ['heading', 'h4'],
+      icon: createElement(IconH4, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(4)),
+    },
+    {
+      id: 'h5',
+      label: 'Heading 5',
+      hint: 'H5',
+      shortcut: 'Ctrl+Alt+5',
+      keywords: ['heading', 'h5'],
+      icon: createElement(IconH5, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(5)),
+    },
+    {
+      id: 'h6',
+      label: 'Heading 6',
+      hint: 'H6',
+      shortcut: 'Ctrl+Alt+6',
+      keywords: ['heading', 'h6'],
+      icon: createElement(IconH6, { size: 16 }),
+      onSelect: () => executeSlashAction(() => handleSlashHeading(6)),
+    },
+    {
+      id: 'bold',
+      label: 'Bold',
+      hint: 'Bold',
+      shortcut: 'Ctrl+B',
+      keywords: ['bold', 'strong'],
+      icon: createElement(IconBold, { size: 16 }),
+      onSelect: () => executeSlashAction(handleBold),
+    },
+    {
+      id: 'italic',
+      label: 'Italic',
+      hint: 'Italic',
+      shortcut: 'Ctrl+I',
+      keywords: ['italic', 'emphasis'],
+      icon: createElement(IconItalic, { size: 16 }),
+      onSelect: () => executeSlashAction(handleItalic),
+    },
+    {
+      id: 'strikethrough',
+      label: 'Strikethrough',
+      hint: 'Strike',
+      shortcut: 'Ctrl+Shift+X',
+      keywords: ['strikethrough', 'strike'],
+      icon: createElement(IconStrikethrough, { size: 16 }),
+      onSelect: () => executeSlashAction(handleStrike),
+    },
+    {
+      id: 'code',
+      label: 'Code',
+      hint: 'Code',
+      shortcut: 'Ctrl+`',
+      keywords: ['code', 'inline'],
+      icon: createElement(IconCode, { size: 16 }),
+      onSelect: () => executeSlashAction(handleCode),
+    },
+    {
+      id: 'blockquote',
+      label: 'Blockquote',
+      hint: 'Quote',
+      shortcut: 'Ctrl+Shift+>',
+      keywords: ['quote', 'blockquote', 'citation'],
+      icon: createElement(IconBlockquote, { size: 16 }),
+      onSelect: () => executeSlashAction(handleSlashQuote),
+    },
+    {
+      id: 'link',
+      label: 'Link',
+      hint: 'Link',
+      shortcut: 'Ctrl+K',
+      keywords: ['link', 'url'],
+      icon: createElement(IconLink, { size: 16 }),
+      onSelect: () => executeSlashAction(handleLink),
+    },
+    {
+      id: 'bullet-list',
+      label: 'Bullet List',
+      hint: 'Bullet',
+      shortcut: 'Ctrl+Shift+8',
+      keywords: ['bullet', 'list', 'unordered'],
+      icon: createElement(IconList, { size: 16 }),
+      onSelect: () => executeSlashAction(handleSlashBulletList),
+    },
+    {
+      id: 'ordered-list',
+      label: 'Ordered List',
+      hint: 'Ordered',
+      shortcut: 'Ctrl+Shift+7',
+      keywords: ['ordered', 'list', 'number', 'numbered'],
+      icon: createElement(IconListNumbers, { size: 16 }),
+      onSelect: () => executeSlashAction(handleSlashOrderedList),
+    },
+    {
+      id: 'task-list',
+      label: 'Task List',
+      hint: 'Check',
+      shortcut: 'Ctrl+Shift+[',
+      keywords: ['task', 'check', 'list', 'todo', 'checkbox'],
+      icon: createElement(IconListCheck, { size: 16 }),
+      onSelect: () => executeSlashAction(handleSlashTaskList),
+    },
+    {
+      id: 'table',
+      label: 'Table',
+      hint: 'Table',
+      keywords: ['table', 'grid'],
+      icon: createElement(IconTable, { size: 16 }),
+      onSelect: () => executeSlashAction(handleSlashInsertTable),
+    },
+    {
+      id: 'image',
+      label: 'Image',
+      hint: 'Img',
+      shortcut: 'Ctrl+Shift+I',
+      keywords: ['image', 'photo', 'upload'],
+      icon: createElement(IconPhoto, { size: 16 }),
+      onSelect: () => executeSlashAction(handleImageUploadFromSlash),
+    },
+    {
+      id: 'divider',
+      label: 'Divider',
+      hint: 'Line',
+      keywords: ['divider', 'hr', 'line', 'separator', 'horizontal rule'],
+      icon: createElement('span', { className: 'text-lg' }, '\u2014'),
+      onSelect: () => executeSlashAction(handleSlashDivider),
+    },
+    {
+      id: 'tag',
+      label: 'Tag',
+      hint: 'Tag',
+      shortcut: 'Ctrl+Shift+#',
+      keywords: ['tag', 'label', 'property', '#'],
+      icon: createElement('span', { className: 'text-sm' }, '#'),
+      onSelect: () => executeSlashAction(handleSlashTag),
+    },
+  ];
+
+  return {
+    slashMenuState,
+    handleSlashMenuSuggest,
+    closeSlashMenu,
+    slashCommands,
+  };
+}


### PR DESCRIPTION
## Summary

Three changes cleaning up slash menu behavior:

### 1. Extract slash menu into a dedicated hook
Moves all slash menu state (`isOpen`, `query`, `position`, `range`), all 11 inline command handlers, and the `slashCommands` array from `MilkdownEditor.tsx` into a new `useSlashMenu(editorRef, handlers)` hook. No behavior change — pure refactor.

### 2. Suppress slash menu on whitespace queries
The slash menu no longer opens when the query after `/` contains whitespace. This prevents false triggers from mid-paragraph slashes, URL-like strings, and `/ ` (slash followed by space). Adds E2E tests for all 6 whitespace edge cases.

### 3. Fix slash menu `scrollIntoView` scrolling the page
Replaces `element.scrollIntoView({ block: 'nearest' })` with explicit `scrollTop` adjustment on the menu's scrollable container. The old code could scroll the page body when the inner overflow container wasn't overflowing (filtered results) or during the CSS entrance animation. Also refactored positioning from React state to direct DOM to eliminate unnecessary re-render cycles from new object references in `useLayoutEffect`.

Closes #63