### PR TITLE
fix: proper markdown export with image extraction

### DIFF
--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -5,6 +5,8 @@ import { config } from 'dotenv';
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 
+export const uploadsDir = resolve(currentDir, '..', 'uploads');
+
 const candidateEnvPaths = [
   resolve(process.cwd(), '.env'),
   resolve(currentDir, '../.env'),

--- a/packages/api/src/routes/export.ts
+++ b/packages/api/src/routes/export.ts
@@ -1,8 +1,8 @@
-import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import JSZip from 'jszip';
 import { pool } from '../db/connection';
+import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import { extractImages, pageToMarkdown } from '../utils/export-helpers';
 
@@ -54,7 +54,6 @@ exportRoute.get(':workspaceId/export', async (c) => {
   const zip = new JSZip();
   const usedNames = new Map<string, number>();
   const allAssets = new Map<string, Buffer>();
-  const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
 
   for (let i = 0; i < pages.length; i++) {
     const page = pages[i];
@@ -70,7 +69,7 @@ exportRoute.get(':workspaceId/export', async (c) => {
     const filename = seenCount > 0 ? `${baseName}-${seenCount + 1}.md` : `${baseName}.md`;
 
     let content = pageToMarkdown(page.ydoc, page.properties, page.icon, title);
-    const extracted = await extractImages(content, uploadsDir);
+    const extracted = await extractImages(content, uploadsDir, workspaceId);
     content = extracted.markdown;
 
     for (const [assetName, assetBuffer] of extracted.assets) {

--- a/packages/api/src/routes/export.ts
+++ b/packages/api/src/routes/export.ts
@@ -1,13 +1,17 @@
+import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import JSZip from 'jszip';
 import { pool } from '../db/connection';
 import { requireAuth } from '../middleware/auth';
+import { extractImages, pageToMarkdown } from '../utils/export-helpers';
 
 type PageExportRow = {
   id: string;
   title: string | null;
   ydoc: Buffer | null;
+  properties: Record<string, unknown> | null;
+  icon: string | null;
 };
 
 const exportRoute = new Hono();
@@ -42,46 +46,45 @@ exportRoute.get(':workspaceId/export', async (c) => {
   await ensureWorkspaceMember(workspaceId, user.id);
 
   const result = await pool.query(
-    'select id, title, ydoc from pages where workspace_id = $1 and is_deleted = false order by parent_id nulls first, position asc',
+    'select id, title, ydoc, properties, icon from pages where workspace_id = $1 and is_deleted = false order by parent_id nulls first, position asc',
     [workspaceId],
   );
 
   const pages = result.rows as PageExportRow[];
   const zip = new JSZip();
   const usedNames = new Map<string, number>();
+  const allAssets = new Map<string, Buffer>();
+  const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
 
-  pages.forEach((page, index) => {
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages[i];
+    if (!page) continue;
     const title =
       typeof page.title === 'string' && page.title.trim().length > 0
         ? page.title.trim()
         : 'Untitled';
     const baseSlug = slugifyFilename(title);
-    const baseName = baseSlug.length > 0 ? baseSlug : `page-${index + 1}`;
+    const baseName = baseSlug.length > 0 ? baseSlug : `page-${i + 1}`;
     const seenCount = usedNames.get(baseName) ?? 0;
     usedNames.set(baseName, seenCount + 1);
     const filename = seenCount > 0 ? `${baseName}-${seenCount + 1}.md` : `${baseName}.md`;
-    let content = '';
-    if (page.ydoc && page.ydoc.length > 0) {
-      const hasNullByte = page.ydoc.includes(0);
-      if (!hasNullByte) {
-        try {
-          content = new TextDecoder().decode(page.ydoc);
-        } catch {
-          content = '';
-        }
+
+    let content = pageToMarkdown(page.ydoc, page.properties, page.icon, title);
+    const extracted = await extractImages(content, uploadsDir);
+    content = extracted.markdown;
+
+    for (const [assetName, assetBuffer] of extracted.assets) {
+      if (!allAssets.has(assetName)) {
+        allAssets.set(assetName, assetBuffer);
       }
     }
-    if (!content.trim()) {
-      content = `# ${title}
 
-`;
-    } else {
-      content = `# ${title}
-
-${content}`;
-    }
     zip.file(filename, content);
-  });
+  }
+
+  for (const [assetName, assetBuffer] of allAssets) {
+    zip.file(`assets/${assetName}`, assetBuffer);
+  }
 
   const buffer = await zip.generateAsync({ type: 'nodebuffer' });
   const arrayBuffer = buffer.buffer.slice(

--- a/packages/api/src/routes/export.ts
+++ b/packages/api/src/routes/export.ts
@@ -5,6 +5,7 @@ import { pool } from '../db/connection';
 import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import { extractImages, pageToMarkdown } from '../utils/export-helpers';
+import { slugifyFilename } from '../utils/filename';
 
 type PageExportRow = {
   id: string;
@@ -28,13 +29,6 @@ const ensureWorkspaceMember = async (workspaceId: string, userId: string) => {
     throw new HTTPException(403, { message: 'Forbidden' });
   }
 };
-
-const slugifyFilename = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 
 exportRoute.get(':workspaceId/export', async (c) => {
   const workspaceId = c.req.param('workspaceId');

--- a/packages/api/src/routes/import.ts
+++ b/packages/api/src/routes/import.ts
@@ -1,10 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
-import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import type { pages } from '../db';
 import { pool } from '../db/connection';
+import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import {
   createYjsDocWithTitle,
@@ -212,8 +212,7 @@ importRoute.post('/markdown', async (c) => {
   const { title: frontmatterTitle, body, properties } = parseFrontmatter(content);
   const title = frontmatterTitle || file.name.replace(/\.md$/, '');
 
-  const uploadDir = path.resolve('uploads');
-  await mkdir(uploadDir, { recursive: true });
+  await mkdir(uploadsDir, { recursive: true });
 
   const { result: processedContent } = processMarkdownImages(body, []);
   const contentForEditor = stripLeadingH1(processedContent, title);

--- a/packages/api/src/routes/obsidian-import.ts
+++ b/packages/api/src/routes/obsidian-import.ts
@@ -5,6 +5,7 @@ import { normalizeTagSlug } from '@markdawn/shared/yjs-helpers';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { pool } from '../db/connection';
+import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import {
   markdownToYjsState,
@@ -248,8 +249,7 @@ obsidianImportRoute.post('/', async (c) => {
   }
 
   const imagePathToUrl = new Map<string, string>();
-  const uploadDir = path.resolve('uploads');
-  await mkdir(uploadDir, { recursive: true });
+  await mkdir(uploadsDir, { recursive: true });
 
   for (const file of imageFiles) {
     try {
@@ -257,7 +257,7 @@ obsidianImportRoute.post('/', async (c) => {
 
       const ext = getExtension(file.path);
       const filename = `${randomUUID()}.${ext}`;
-      const filePath = path.join(uploadDir, filename);
+      const filePath = path.join(uploadsDir, filename);
       const buffer = Buffer.from(file.data, 'base64');
       await writeFile(filePath, buffer);
 

--- a/packages/api/src/routes/pages.test.ts
+++ b/packages/api/src/routes/pages.test.ts
@@ -326,7 +326,7 @@ describe('pages API', () => {
       });
       expect(res.status).toBe(200);
       expect(res.headers.get('Content-Type')).toBe('text/markdown');
-      expect(res.headers.get('Content-Disposition')).toContain('Export.md');
+      expect(res.headers.get('Content-Disposition')).toContain('export.md');
       const body = await res.text();
       expect(typeof body).toBe('string');
     });

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from 'node:crypto';
-import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import JSZip from 'jszip';
@@ -7,6 +6,7 @@ import { marked } from 'marked';
 import * as Y from 'yjs';
 import type { pages } from '../db';
 import { pool } from '../db/connection';
+import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import { extractImages, pageToMarkdown } from '../utils/export-helpers';
 import {
@@ -502,10 +502,9 @@ pagesRoute.get(':id/export/markdown', async (c) => {
   const user = c.get('user') as { id: string };
   await ensureWorkspaceMember(page.workspaceId, user.id);
 
-  const baseFilename = slugifyFilename(page.title || 'Untitled');
+  const baseFilename = slugifyFilename(page.title || 'Untitled') || 'untitled';
   const markdown = pageToMarkdown(page.ydoc, page.properties, page.icon, page.title || undefined);
-  const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
-  const extracted = await extractImages(markdown, uploadsDir);
+  const extracted = await extractImages(markdown, uploadsDir, page.workspaceId ?? undefined);
 
   if (extracted.assets.size === 0) {
     c.header('Content-Type', 'text/markdown');

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -1,11 +1,14 @@
 import { randomBytes } from 'node:crypto';
+import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
+import JSZip from 'jszip';
 import { marked } from 'marked';
 import * as Y from 'yjs';
 import type { pages } from '../db';
 import { pool } from '../db/connection';
 import { requireAuth } from '../middleware/auth';
+import { extractImages, pageToMarkdown } from '../utils/export-helpers';
 import {
   createEmptyYjsDoc,
   createYjsDocWithTitle,
@@ -499,21 +502,39 @@ pagesRoute.get(':id/export/markdown', async (c) => {
   const user = c.get('user') as { id: string };
   await ensureWorkspaceMember(page.workspaceId, user.id);
 
-  const filename = `${page.title || 'Untitled'}.md`;
-  c.header('Content-Type', 'text/markdown');
-  c.header('Content-Disposition', `attachment; filename="${filename}"`);
-  if (!page.ydoc || page.ydoc.length === 0) {
-    return c.body('');
+  const baseFilename = slugifyFilename(page.title || 'Untitled');
+  const markdown = pageToMarkdown(page.ydoc, page.properties, page.icon, page.title || undefined);
+  const uploadsDir = path.resolve(__dirname, '..', '..', 'uploads');
+  const extracted = await extractImages(markdown, uploadsDir);
+
+  if (extracted.assets.size === 0) {
+    c.header('Content-Type', 'text/markdown');
+    c.header('Content-Disposition', `attachment; filename="${baseFilename}.md"`);
+    return c.body(extracted.markdown);
   }
 
-  try {
-    const decoded = new TextDecoder().decode(page.ydoc);
-    c.header('Content-Type', 'text/markdown');
-    return c.body(decoded);
-  } catch {
-    throw new HTTPException(500, { message: 'Failed to decode page content' });
+  const zip = new JSZip();
+  zip.file(`${baseFilename}.md`, extracted.markdown);
+  for (const [assetName, assetBuffer] of extracted.assets) {
+    zip.file(`assets/${assetName}`, assetBuffer);
   }
+
+  const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+  const arrayBuffer = buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength,
+  ) as ArrayBuffer;
+  c.header('Content-Type', 'application/zip');
+  c.header('Content-Disposition', `attachment; filename="${baseFilename}.zip"`);
+  return c.newResponse(arrayBuffer, 200);
 });
+
+const slugifyFilename = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 
 pagesRoute.post(':id/import/markdown', async (c) => {
   const pageId = c.req.param('id');

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -9,6 +9,7 @@ import { pool } from '../db/connection';
 import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 import { extractImages, pageToMarkdown } from '../utils/export-helpers';
+import { slugifyFilename } from '../utils/filename';
 import {
   createEmptyYjsDoc,
   createYjsDocWithTitle,
@@ -527,13 +528,6 @@ pagesRoute.get(':id/export/markdown', async (c) => {
   c.header('Content-Disposition', `attachment; filename="${baseFilename}.zip"`);
   return c.newResponse(arrayBuffer, 200);
 });
-
-const slugifyFilename = (value: string) =>
-  value
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
 
 pagesRoute.post(':id/import/markdown', async (c) => {
   const pageId = c.req.param('id');

--- a/packages/api/src/routes/uploads.ts
+++ b/packages/api/src/routes/uploads.ts
@@ -64,7 +64,7 @@ uploadsRoute.post('/', async (c) => {
     throw new HTTPException(400, { message: 'File must be 10MB or less' });
   }
 
-  const uploadDir = path.resolve('uploads');
+  const uploadDir = path.resolve(__dirname, '..', '..', 'uploads');
   await mkdir(uploadDir, { recursive: true });
 
   const filename = `${randomUUID()}.${extension}`;
@@ -99,7 +99,7 @@ uploadsRoute.get('/:filename', async (c) => {
   // Check workspace membership
   await ensureWorkspaceMember(upload.workspace_id, user.id);
 
-  const filePath = path.resolve('uploads', filename);
+  const filePath = path.resolve(__dirname, '..', '..', 'uploads', filename);
 
   try {
     const fileBuffer = await readFile(filePath);

--- a/packages/api/src/routes/uploads.ts
+++ b/packages/api/src/routes/uploads.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { Hono } from 'hono';
 import { HTTPException } from 'hono/http-exception';
 import { pool } from '../db/connection';
+import { uploadsDir } from '../env';
 import { requireAuth } from '../middleware/auth';
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
@@ -64,11 +65,10 @@ uploadsRoute.post('/', async (c) => {
     throw new HTTPException(400, { message: 'File must be 10MB or less' });
   }
 
-  const uploadDir = path.resolve(__dirname, '..', '..', 'uploads');
-  await mkdir(uploadDir, { recursive: true });
+  await mkdir(uploadsDir, { recursive: true });
 
   const filename = `${randomUUID()}.${extension}`;
-  const filePath = path.join(uploadDir, filename);
+  const filePath = path.join(uploadsDir, filename);
   const buffer = Buffer.from(await file.arrayBuffer());
   await writeFile(filePath, buffer);
 
@@ -99,7 +99,7 @@ uploadsRoute.get('/:filename', async (c) => {
   // Check workspace membership
   await ensureWorkspaceMember(upload.workspace_id, user.id);
 
-  const filePath = path.resolve(__dirname, '..', '..', 'uploads', filename);
+  const filePath = path.join(uploadsDir, filename);
 
   try {
     const fileBuffer = await readFile(filePath);

--- a/packages/api/src/utils/export-helpers.ts
+++ b/packages/api/src/utils/export-helpers.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { yDocToMarkdown } from '@markdawn/shared/yjs-helpers';
+import { pool } from '../db/connection';
 
 /**
  * Matches markdown image syntax: ![alt](src) with optional title.
@@ -94,11 +95,13 @@ export interface ExtractedImages {
 export async function extractImages(
   markdown: string,
   uploadsDir: string,
+  workspaceId?: string,
 ): Promise<ExtractedImages> {
   const { masked, blocks } = maskCodeBlocks(markdown);
 
   const assets = new Map<string, Buffer>();
   const urlToAssetName = new Map<string, string>();
+  const contentHashToAssetName = new Map<string, string>();
   let result = masked;
 
   const matches: ImageMatch[] = [];
@@ -117,6 +120,29 @@ export async function extractImages(
             ? '()'
             : '';
     matches.push({ full: match[0], alt: match[1] ?? '', src, title, titleDelim });
+  }
+
+  const serverFilenames = new Set<string>();
+  for (const { src } of matches) {
+    if (src.startsWith('/api/uploads/') || src.startsWith('/uploads/')) {
+      const filename = src.startsWith('/api/uploads/')
+        ? src.replace('/api/uploads/', '')
+        : src.replace('/uploads/', '');
+      if (isValidUploadFilename(filename)) {
+        serverFilenames.add(filename);
+      }
+    }
+  }
+
+  const authorizedFiles = new Set<string>();
+  if (workspaceId && serverFilenames.size > 0) {
+    const uploadResult = await pool.query(
+      'select filename from uploads where filename = any($1) and workspace_id = $2',
+      [Array.from(serverFilenames), workspaceId],
+    );
+    for (const row of uploadResult.rows as { filename: string }[]) {
+      authorizedFiles.add(row.filename);
+    }
   }
 
   for (const { full, alt, src, title, titleDelim } of matches) {
@@ -143,9 +169,13 @@ export async function extractImages(
       } catch {
         continue;
       }
-    } else if (src.startsWith('/api/uploads/')) {
-      const filename = src.replace('/api/uploads/', '');
+    } else if (src.startsWith('/api/uploads/') || src.startsWith('/uploads/')) {
+      const filename = src.startsWith('/api/uploads/')
+        ? src.replace('/api/uploads/', '')
+        : src.replace('/uploads/', '');
       if (!isValidUploadFilename(filename)) continue;
+
+      if (workspaceId && !authorizedFiles.has(filename)) continue;
 
       const filePath = path.join(uploadsDir, filename);
       try {
@@ -174,23 +204,24 @@ export async function extractImages(
       continue;
     }
 
-    let finalName = assetName;
-    let counter = 1;
-    for (const [name, existingBuffer] of assets) {
-      if (existingBuffer.equals(buffer)) {
-        finalName = name;
-        break;
+    const contentHash = createHash('sha256').update(buffer).digest('hex');
+    const hashToName = contentHashToAssetName.get(contentHash);
+    let finalName = hashToName ?? assetName;
+
+    if (hashToName) {
+      finalName = hashToName;
+    } else if (assets.has(finalName) && !assets.get(finalName)?.equals(buffer)) {
+      const ext = path.extname(assetName);
+      const base = path.basename(assetName, ext);
+      let counter = 1;
+      while (assets.has(finalName) && !assets.get(finalName)?.equals(buffer)) {
+        finalName = `${base}-${counter}${ext}`;
+        counter++;
       }
     }
 
-    while (assets.has(finalName) && !assets.get(finalName)?.equals(buffer)) {
-      const ext = path.extname(assetName);
-      const base = path.basename(assetName, ext);
-      finalName = `${base}-${counter}${ext}`;
-      counter++;
-    }
-
     assets.set(finalName, buffer);
+    contentHashToAssetName.set(contentHash, finalName);
     urlToAssetName.set(src, finalName);
     result = result.replaceAll(full, `![${alt}](./assets/${finalName}${titlePart})`);
   }
@@ -261,9 +292,17 @@ function yamlScalar(value: unknown): string {
       /[:#]/.test(value) ||
       /^[!&*?'"|>{%\[]/.test(value) ||
       value.includes("'") ||
-      value.includes('"');
+      value.includes('"') ||
+      value.includes('\n') ||
+      value.includes('\r') ||
+      value.includes('\t');
     if (needsQuotes) {
-      const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const escaped = value
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(/\t/g, '\\t');
       return `"${escaped}"`;
     }
     return value;

--- a/packages/api/src/utils/export-helpers.ts
+++ b/packages/api/src/utils/export-helpers.ts
@@ -1,0 +1,300 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { yDocToMarkdown } from '@markdawn/shared/yjs-helpers';
+
+/**
+ * Matches markdown image syntax: ![alt](src) with optional title.
+ * Capture groups: 1=alt, 2=src (without title), 3=title (optional).
+ * Handles title in double quotes, single quotes, or parentheses.
+ */
+const IMAGE_REGEX =
+  /!\[([^\]]*)\]\((?:<([^>]*)>|([^)\s]+))(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)/g;
+
+const CODE_FENCE_REGEX = /```[\s\S]*?```/g;
+const INLINE_CODE_REGEX = /`[^`]+`/g;
+
+const PLACEHOLDER_PREFIX = '\u0000CODE_';
+const PLACEHOLDER_SUFFIX = '\u0000';
+
+interface ImageMatch {
+  full: string;
+  alt: string;
+  src: string;
+  title: string;
+  titleDelim: '"' | "'" | '()' | '';
+}
+
+function maskCodeBlocks(markdown: string): { masked: string; blocks: string[] } {
+  const blocks: string[] = [];
+  const masked = markdown
+    .replace(CODE_FENCE_REGEX, (m) => {
+      blocks.push(m);
+      return `${PLACEHOLDER_PREFIX}${blocks.length - 1}${PLACEHOLDER_SUFFIX}`;
+    })
+    .replace(INLINE_CODE_REGEX, (m) => {
+      blocks.push(m);
+      return `${PLACEHOLDER_PREFIX}${blocks.length - 1}${PLACEHOLDER_SUFFIX}`;
+    });
+  return { masked, blocks };
+}
+
+function restoreCodeBlocks(masked: string, blocks: string[]): string {
+  let result = masked;
+  for (let i = 0; i < blocks.length; i++) {
+    result = result.replace(`${PLACEHOLDER_PREFIX}${i}${PLACEHOLDER_SUFFIX}`, blocks[i] ?? '');
+  }
+  return result;
+}
+
+function extractSrcFromMatch(match: RegExpExecArray): string | null {
+  // Group 2 is <url> form, group 3 is bare url form
+  return match[2] ?? match[3] ?? null;
+}
+
+function isValidUploadFilename(filename: string): boolean {
+  if (!filename || filename.startsWith('.')) return false;
+  return /^[a-zA-Z0-9\-_.]+$/.test(filename);
+}
+
+function resolveMimeType(header: string): string | null {
+  const match = header.match(/data:(image\/[\w+.-]+);base64/);
+  if (!match) return null;
+  return match[1] ?? null;
+}
+
+function resolveExtension(mimeType: string): string {
+  const parts = mimeType.split('/');
+  const subtype = parts[1] ?? 'bin';
+  // image/svg+xml → svg, image/vnd.microsoft.icon → ico
+  const base = subtype.split('+')[0] ?? subtype;
+  return base;
+}
+
+/**
+ * Result of extracting images from markdown.
+ */
+export interface ExtractedImages {
+  markdown: string;
+  assets: Map<string, Buffer>;
+}
+
+/**
+ * Scans markdown for images, extracts them from disk or decodes base64,
+ * and rewrites references to use relative ./assets/ paths.
+ *
+ * Handles three image source types:
+ * 1. Server URLs: /api/uploads/filename.png → read from uploads/ directory
+ * 2. Base64 data URIs: data:image/png;base64,... → decode to buffer
+ * 3. External URLs: https://... → left as-is (not downloaded)
+ *
+ * Code blocks and inline code are masked before scanning to prevent
+ * image syntax inside code from being corrupted.
+ */
+export async function extractImages(
+  markdown: string,
+  uploadsDir: string,
+): Promise<ExtractedImages> {
+  const { masked, blocks } = maskCodeBlocks(markdown);
+
+  const assets = new Map<string, Buffer>();
+  const urlToAssetName = new Map<string, string>();
+  let result = masked;
+
+  const matches: ImageMatch[] = [];
+  let match: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec pattern
+  while ((match = IMAGE_REGEX.exec(masked)) !== null) {
+    const src = extractSrcFromMatch(match);
+    if (!src) continue;
+    const title = match[4] ?? match[5] ?? match[6] ?? '';
+    const titleDelim =
+      match[4] !== undefined
+        ? '"'
+        : match[5] !== undefined
+          ? "'"
+          : match[6] !== undefined
+            ? '()'
+            : '';
+    matches.push({ full: match[0], alt: match[1] ?? '', src, title, titleDelim });
+  }
+
+  for (const { full, alt, src, title, titleDelim } of matches) {
+    let buffer: Buffer | null = null;
+    let assetName: string | null = null;
+
+    if (src.startsWith('data:image/')) {
+      const commaIdx = src.indexOf(',');
+      if (commaIdx === -1) continue;
+
+      const header = src.slice(0, commaIdx);
+      const data = src.slice(commaIdx + 1);
+
+      const mimeType = resolveMimeType(header);
+      if (!mimeType) continue;
+
+      const ext = resolveExtension(mimeType);
+
+      try {
+        const decoded = Buffer.from(data, 'base64');
+        const hash = createHash('sha256').update(decoded).digest('hex').slice(0, 12);
+        assetName = `image-${hash}.${ext}`;
+        buffer = decoded;
+      } catch {
+        continue;
+      }
+    } else if (src.startsWith('/api/uploads/')) {
+      const filename = src.replace('/api/uploads/', '');
+      if (!isValidUploadFilename(filename)) continue;
+
+      const filePath = path.join(uploadsDir, filename);
+      try {
+        buffer = await readFile(filePath);
+        assetName = filename;
+      } catch {
+        continue;
+      }
+    } else {
+      continue;
+    }
+
+    if (!buffer || !assetName) continue;
+
+    const titlePart = title
+      ? titleDelim === '()'
+        ? ` (${title})`
+        : ` ${titleDelim}${title}${titleDelim}`
+      : '';
+
+    if (urlToAssetName.has(src)) {
+      const existing = urlToAssetName.get(src);
+      if (existing) {
+        result = result.replaceAll(full, `![${alt}](./assets/${existing}${titlePart})`);
+      }
+      continue;
+    }
+
+    let finalName = assetName;
+    let counter = 1;
+    for (const [name, existingBuffer] of assets) {
+      if (existingBuffer.equals(buffer)) {
+        finalName = name;
+        break;
+      }
+    }
+
+    while (assets.has(finalName) && !assets.get(finalName)?.equals(buffer)) {
+      const ext = path.extname(assetName);
+      const base = path.basename(assetName, ext);
+      finalName = `${base}-${counter}${ext}`;
+      counter++;
+    }
+
+    assets.set(finalName, buffer);
+    urlToAssetName.set(src, finalName);
+    result = result.replaceAll(full, `![${alt}](./assets/${finalName}${titlePart})`);
+  }
+
+  return { markdown: restoreCodeBlocks(result, blocks), assets };
+}
+
+/**
+ * Converts properties + icon to a YAML frontmatter string.
+ * Returns empty string if there's nothing to put in frontmatter.
+ */
+export function serializeFrontmatter(
+  properties: Record<string, unknown> | null,
+  icon: string | null,
+): string {
+  const data: Record<string, unknown> = {};
+
+  if (icon) {
+    data.icon = icon;
+  }
+
+  if (properties && typeof properties === 'object') {
+    for (const [key, value] of Object.entries(properties)) {
+      if (value !== null && value !== undefined) {
+        data[key] = value;
+      }
+    }
+  }
+
+  if (Object.keys(data).length === 0) return '';
+
+  const lines: string[] = ['---'];
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        lines.push(`${key}:`);
+        for (const item of value) {
+          lines.push(`  - ${yamlScalar(item)}`);
+        }
+      } else {
+        lines.push(`${key}: []`);
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      lines.push(`${key}: ${JSON.stringify(value)}`);
+    } else {
+      lines.push(`${key}: ${yamlScalar(value)}`);
+    }
+  }
+  lines.push('---');
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+function yamlScalar(value: unknown): string {
+  if (typeof value === 'string') {
+    const needsQuotes =
+      value === '' ||
+      value === 'true' ||
+      value === 'false' ||
+      value === 'null' ||
+      value === '~' ||
+      value === 'yes' ||
+      value === 'no' ||
+      value === 'on' ||
+      value === 'off' ||
+      /^[0-9]/.test(value) ||
+      /[:#]/.test(value) ||
+      /^[!&*?'"|>{%\[]/.test(value) ||
+      value.includes("'") ||
+      value.includes('"');
+    if (needsQuotes) {
+      const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      return `"${escaped}"`;
+    }
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value === null || value === undefined) {
+    return '~';
+  }
+  return String(value);
+}
+
+/**
+ * Converts a page's Yjs binary content to a full markdown document
+ * including YAML frontmatter (properties + icon) and a title heading.
+ */
+export function pageToMarkdown(
+  ydoc: Buffer | Uint8Array | null,
+  properties: Record<string, unknown> | null,
+  icon: string | null,
+  title?: string,
+): string {
+  let body = '';
+  if (ydoc && ydoc.length > 0) {
+    body = yDocToMarkdown(ydoc instanceof Buffer ? new Uint8Array(ydoc) : ydoc);
+  }
+
+  const frontmatter = serializeFrontmatter(properties, icon);
+
+  const heading = title ? `# ${title}\n\n` : '';
+
+  return frontmatter + heading + body;
+}

--- a/packages/api/src/utils/export-helpers.ts
+++ b/packages/api/src/utils/export-helpers.ts
@@ -6,8 +6,8 @@ import { pool } from '../db/connection';
 
 /**
  * Matches markdown image syntax: ![alt](src) with optional title.
- * Capture groups: 1=alt, 2=src (without title), 3=title (optional).
- * Handles title in double quotes, single quotes, or parentheses.
+ * Capture groups: 1=alt, 2=src (angle-bracket form), 3=src (bare form),
+ * 4=title (double-quoted), 5=title (single-quoted), 6=title (parenthesized).
  */
 const IMAGE_REGEX =
   /!\[([^\]]*)\]\((?:<([^>]*)>|([^)\s]+))(?:\s+(?:"([^"]*)"|'([^']*)'|\(([^)]*)\)))?\)/g;
@@ -64,10 +64,17 @@ function resolveMimeType(header: string): string | null {
   return match[1] ?? null;
 }
 
+const MIME_TO_EXT: Record<string, string> = {
+  'vnd.microsoft.icon': 'ico',
+  'x-icon': 'ico',
+};
+
 function resolveExtension(mimeType: string): string {
   const parts = mimeType.split('/');
   const subtype = parts[1] ?? 'bin';
-  // image/svg+xml → svg, image/vnd.microsoft.icon → ico
+  // Known MIME→extension mappings for non-standard subtypes
+  if (MIME_TO_EXT[subtype]) return MIME_TO_EXT[subtype];
+  // image/svg+xml → svg (everything after + is the vendor extension)
   const base = subtype.split('+')[0] ?? subtype;
   return base;
 }
@@ -255,19 +262,20 @@ export function serializeFrontmatter(
 
   const lines: string[] = ['---'];
   for (const [key, value] of Object.entries(data)) {
+    const keyStr = yamlScalar(key);
     if (Array.isArray(value)) {
       if (value.length > 0) {
-        lines.push(`${key}:`);
+        lines.push(`${keyStr}:`);
         for (const item of value) {
           lines.push(`  - ${yamlScalar(item)}`);
         }
       } else {
-        lines.push(`${key}: []`);
+        lines.push(`${keyStr}: []`);
       }
     } else if (typeof value === 'object' && value !== null) {
-      lines.push(`${key}: ${JSON.stringify(value)}`);
+      lines.push(`${keyStr}: ${JSON.stringify(value)}`);
     } else {
-      lines.push(`${key}: ${yamlScalar(value)}`);
+      lines.push(`${keyStr}: ${yamlScalar(value)}`);
     }
   }
   lines.push('---');

--- a/packages/api/src/utils/export-helpers.unit.test.ts
+++ b/packages/api/src/utils/export-helpers.unit.test.ts
@@ -54,7 +54,6 @@ describe('export-helpers / extractImages', () => {
     const md = `![a](data:image/png;base64,${b64})\n\n![b](data:image/png;base64,${b64})`;
     const result = await extractImages(md, tmpDir);
     expect(result.assets.size).toBe(1);
-    const assetNames = [...result.assets.keys()];
     const occurrences = result.markdown.match(/image-[a-f0-9]{12}\.png/g);
     expect(occurrences?.length).toBe(2);
     expect(new Set(occurrences).size).toBe(1);

--- a/packages/api/src/utils/export-helpers.unit.test.ts
+++ b/packages/api/src/utils/export-helpers.unit.test.ts
@@ -2,14 +2,15 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { extractImages } from './export-helpers';
+import { extractImages, serializeFrontmatter } from './export-helpers';
 
 describe('export-helpers / extractImages', () => {
   let tmpDir: string;
 
   beforeAll(async () => {
     const dirPath = path.join(os.tmpdir(), 'extract-images-test');
-    tmpDir = (await mkdir(dirPath, { recursive: true })) as string;
+    await mkdir(dirPath, { recursive: true });
+    tmpDir = dirPath;
     const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     await writeFile(path.join(tmpDir, 'test-image.png'), pngHeader);
     await writeFile(path.join(tmpDir, 'photo.jpg'), Buffer.from([0xff, 0xd8, 0xff]));
@@ -166,5 +167,32 @@ describe('export-helpers / extractImages', () => {
     const result = await extractImages(md, tmpDir);
     expect(result.markdown).toBe('![test](./assets/test-image.png)');
     expect(result.assets.size).toBe(1);
+  });
+});
+
+describe('export-helpers / serializeFrontmatter', () => {
+  it('escapes newlines in string values', () => {
+    const result = serializeFrontmatter({ desc: 'line1\nline2' }, null);
+    expect(result).toContain('desc: "line1\\nline2"');
+  });
+
+  it('escapes tabs in string values', () => {
+    const result = serializeFrontmatter({ code: 'a\tb' }, null);
+    expect(result).toContain('code: "a\\tb"');
+  });
+
+  it('escapes carriage returns in string values', () => {
+    const result = serializeFrontmatter({ text: 'line1\r\nline2' }, null);
+    expect(result).toContain('text: "line1\\r\\nline2"');
+  });
+
+  it('quotes values starting with numbers', () => {
+    const result = serializeFrontmatter({ version: '1.0.0' }, null);
+    expect(result).toContain('version: "1.0.0"');
+  });
+
+  it('quotes boolean-like strings', () => {
+    const result = serializeFrontmatter({ flag: 'true' }, null);
+    expect(result).toContain('flag: "true"');
   });
 });

--- a/packages/api/src/utils/export-helpers.unit.test.ts
+++ b/packages/api/src/utils/export-helpers.unit.test.ts
@@ -1,0 +1,170 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { extractImages } from './export-helpers';
+
+describe('export-helpers / extractImages', () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    const dirPath = path.join(os.tmpdir(), 'extract-images-test');
+    tmpDir = (await mkdir(dirPath, { recursive: true })) as string;
+    const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    await writeFile(path.join(tmpDir, 'test-image.png'), pngHeader);
+    await writeFile(path.join(tmpDir, 'photo.jpg'), Buffer.from([0xff, 0xd8, 0xff]));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns unchanged markdown when no images', async () => {
+    const md = '# Hello\n\nSome text with **bold** and [link](url).';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe(md);
+    expect(result.assets.size).toBe(0);
+  });
+
+  it('extracts server URL images to assets', async () => {
+    const md = '![test](/api/uploads/test-image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![test](./assets/test-image.png)');
+    expect(result.assets.size).toBe(1);
+    expect(result.assets.has('test-image.png')).toBe(true);
+  });
+
+  it('extracts base64 images to assets with hash filename', async () => {
+    const md = '![logo](data:image/png;base64,iVBORw0KGgo=)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toMatch(/!\[logo\]\(\.\/assets\/image-[a-f0-9]{12}\.png\)/);
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('deduplicates same server URL', async () => {
+    const md = '![a](/api/uploads/test-image.png)\n\n![b](/api/uploads/test-image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toContain('./assets/test-image.png');
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('deduplicates same base64 content', async () => {
+    const b64 = 'iVBORw0KGgo=';
+    const md = `![a](data:image/png;base64,${b64})\n\n![b](data:image/png;base64,${b64})`;
+    const result = await extractImages(md, tmpDir);
+    expect(result.assets.size).toBe(1);
+    const assetNames = [...result.assets.keys()];
+    const occurrences = result.markdown.match(/image-[a-f0-9]{12}\.png/g);
+    expect(occurrences?.length).toBe(2);
+    expect(new Set(occurrences).size).toBe(1);
+  });
+
+  it('handles filename collisions with counter suffix', async () => {
+    const b64 = Buffer.from('different-content').toString('base64');
+    const md = `![a](data:image/png;base64,${b64})`;
+    const result = await extractImages(md, tmpDir);
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('skips external URLs', async () => {
+    const md = '![ext](https://example.com/image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe(md);
+    expect(result.assets.size).toBe(0);
+  });
+
+  it('skips missing server files', async () => {
+    const md = '![missing](/api/uploads/nonexistent.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe(md);
+    expect(result.assets.size).toBe(0);
+  });
+
+  it('handles multiple different images', async () => {
+    const md = '![one](/api/uploads/test-image.png)\n\n![two](/api/uploads/photo.jpg)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toContain('./assets/test-image.png');
+    expect(result.markdown).toContain('./assets/photo.jpg');
+    expect(result.assets.size).toBe(2);
+  });
+
+  it('handles images with empty alt text', async () => {
+    const md = '![](/api/uploads/test-image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![](./assets/test-image.png)');
+  });
+
+  it('handles images with special characters in alt', async () => {
+    const md = '![my **bold** image](/api/uploads/test-image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![my **bold** image](./assets/test-image.png)');
+  });
+
+  it('rejects path traversal in server URLs', async () => {
+    const md = '![hack](/api/uploads/../../../etc/passwd)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe(md);
+    expect(result.assets.size).toBe(0);
+  });
+
+  it('rejects hidden filenames', async () => {
+    const md = '![hack](/api/uploads/.env)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe(md);
+    expect(result.assets.size).toBe(0);
+  });
+
+  it('does not replace images inside fenced code blocks', async () => {
+    const md =
+      '```md\n![example](/api/uploads/test-image.png)\n```\n\nReal: ![ok](/api/uploads/test-image.png)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toContain('```md\n![example](/api/uploads/test-image.png)\n```');
+    expect(result.markdown).toContain('Real: ![ok](./assets/test-image.png)');
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('does not replace images inside inline code', async () => {
+    const md =
+      'Use `![example](/api/uploads/test-image.png)` in your docs.\n\nBut ![real](/api/uploads/test-image.png) works.';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toContain('`![example](/api/uploads/test-image.png)`');
+    expect(result.markdown).toContain('![real](./assets/test-image.png)');
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('extracts images with titles', async () => {
+    const md = '![test](/api/uploads/test-image.png "My Title")';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![test](./assets/test-image.png "My Title")');
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('extracts images with single-quoted titles', async () => {
+    const md = "![test](/api/uploads/test-image.png 'My Title')";
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe("![test](./assets/test-image.png 'My Title')");
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('extracts base64 SVG images', async () => {
+    const svgB64 = Buffer.from('<svg></svg>').toString('base64');
+    const md = `![icon](data:image/svg+xml;base64,${svgB64})`;
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toMatch(/!\[icon\]\(\.\/assets\/image-[a-f0-9]{12}\.svg\)/);
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('handles images with parenthesized titles', async () => {
+    const md = '![test](/api/uploads/test-image.png (My Title))';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![test](./assets/test-image.png (My Title))');
+    expect(result.assets.size).toBe(1);
+  });
+
+  it('handles images with angle-bracket URLs', async () => {
+    const md = '![test](</api/uploads/test-image.png>)';
+    const result = await extractImages(md, tmpDir);
+    expect(result.markdown).toBe('![test](./assets/test-image.png)');
+    expect(result.assets.size).toBe(1);
+  });
+});

--- a/packages/api/src/utils/filename.ts
+++ b/packages/api/src/utils/filename.ts
@@ -1,0 +1,7 @@
+export function slugifyFilename(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/packages/shared/src/utils/yjs-helpers.ts
+++ b/packages/shared/src/utils/yjs-helpers.ts
@@ -13,79 +13,391 @@ export interface ConnectionDraft {
   linkContext?: string;
 }
 
+// ---------------------------------------------------------------------------
+// Markdown export
+// ---------------------------------------------------------------------------
+
+interface DeltaSegment {
+  insert: string;
+  attributes?: Record<string, unknown>;
+}
+
+const MARK_ORDER = ['strong', 'emphasis', 'inlineCode', 'strike_through'] as const;
+
+const MARK_DELIMITERS: Record<string, [string, string]> = {
+  strong: ['**', '**'],
+  emphasis: ['*', '*'],
+  inlineCode: ['`', '`'],
+  strike_through: ['~~', '~~'],
+};
+
+/** Exported for testing. */
 export function yDocToMarkdown(update: Uint8Array): string {
   const doc = new Y.Doc();
   Y.applyUpdate(doc, update);
   const fragment = doc.getXmlFragment('prosemirror');
-  return xmlElementToMarkdown(fragment);
+  return renderBlockChildren(fragment, 0);
 }
+
+// ---- Block rendering ----
+
+function renderBlockChildren(element: Y.XmlFragment | Y.XmlElement, depth: number): string {
+  let result = '';
+
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+
+    if (child instanceof Y.XmlText) {
+      // Block-level XmlText shouldn't happen in a valid prosemirror doc,
+      // but handle it gracefully as inline content.
+      result += renderDelta(child.toDelta() as DeltaSegment[]);
+    } else if (child instanceof Y.XmlElement) {
+      result += renderBlockElement(child, depth);
+    }
+  }
+
+  return result;
+}
+
+function renderBlockElement(element: Y.XmlElement, depth: number): string {
+  switch (element.nodeName) {
+    case 'paragraph':
+      return `${renderInlineContent(element)}\n\n`;
+
+    case 'heading': {
+      const level = Number.parseInt(element.getAttribute('level') || '1', 10);
+      return `${'#'.repeat(Math.min(Math.max(level, 1), 6))} ${renderInlineContent(element)}\n\n`;
+    }
+
+    case 'code_block': {
+      const lang = element.getAttribute('language') || '';
+      const code = element.get(0);
+      const codeText = code instanceof Y.XmlText ? code.toString() : '';
+      return `\`\`\`${lang}\n${codeText}\n\`\`\`\n\n`;
+    }
+
+    case 'blockquote': {
+      const inner = renderBlockChildren(element, depth + 1).replace(/\n\n$/, '');
+      if (!inner.trim()) return '\n';
+      const lines = inner.split('\n');
+      return `${lines.map((l) => (l ? `> ${l}` : '>')).join('\n')}\n\n`;
+    }
+
+    case 'bullet_list':
+      return renderList(element, depth, false);
+
+    case 'ordered_list':
+      return renderList(element, depth, true);
+
+    case 'hr':
+      return '---\n\n';
+
+    case 'table':
+      return renderTable(element);
+
+    case 'callout':
+      return renderCallout(element, depth);
+
+    default:
+      // Treat unknown block nodes as inline content
+      return `${renderInlineContent(element)}\n\n`;
+  }
+}
+
+// ---- List rendering ----
+
+function renderList(element: Y.XmlElement, depth: number, ordered: boolean): string {
+  const items: string[] = [];
+  let counter = Number(element.getAttribute('order') || '1');
+  const indent = '  '.repeat(depth);
+
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+    if (!(child instanceof Y.XmlElement) || child.nodeName !== 'list_item') continue;
+
+    const prefix = ordered ? `${counter}. ` : '- ';
+    const checked = child.getAttribute('checked');
+    const taskPrefix = checked != null ? (checked === 'true' ? '[x] ' : '[ ] ') : '';
+    const itemContent = renderListItemContent(child, depth + 1);
+
+    items.push(`${indent}${prefix}${taskPrefix}${itemContent.trimStart().trimEnd()}`);
+    counter++;
+  }
+
+  return `${items.join('\n')}\n`;
+}
+
+function renderListItemContent(element: Y.XmlElement, depth: number): string {
+  let result = '';
+
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+
+    if (child instanceof Y.XmlText) {
+      result += renderDelta(child.toDelta() as DeltaSegment[]);
+    } else if (child instanceof Y.XmlElement) {
+      switch (child.nodeName) {
+        case 'paragraph':
+          result += renderInlineContent(child);
+          break;
+        case 'bullet_list':
+        case 'ordered_list':
+          result += `\n${renderList(child, depth, child.nodeName === 'ordered_list')}`;
+          break;
+        default:
+          result += renderBlockElement(child, depth);
+      }
+    }
+  }
+
+  return result;
+}
+
+// ---- Table rendering ----
+
+function renderTable(element: Y.XmlElement): string {
+  const rows: string[][] = [];
+  const alignments: (string | null)[] = [];
+
+  for (let i = 0; i < element.length; i++) {
+    const row = element.get(i);
+    if (!(row instanceof Y.XmlElement)) continue;
+
+    const cells: string[] = [];
+    for (let j = 0; j < row.length; j++) {
+      const cell = row.get(j);
+      if (!(cell instanceof Y.XmlElement)) continue;
+
+      cells.push(renderInlineContent(cell));
+
+      if (row.nodeName === 'table_header_row' && j >= alignments.length) {
+        alignments.push(cell.getAttribute('alignment') || null);
+      }
+    }
+    rows.push(cells);
+  }
+
+  if (rows.length === 0) return '';
+
+  const numCols = Math.max(...rows.map((r) => r.length), alignments.length);
+  while (alignments.length < numCols) alignments.push(null);
+
+  const alignRow = alignments.map((a) => {
+    if (a === 'center') return ':---:';
+    if (a === 'right') return '---:';
+    if (a === 'left') return ':---';
+    return '---';
+  });
+
+  const lines = rows.map((row) => {
+    while (row.length < numCols) row.push('');
+    return `| ${row.join(' | ')} |`;
+  });
+
+  // Insert alignment row after first (header) row
+  lines.splice(1, 0, `| ${alignRow.join(' | ')} |`);
+
+  return `${lines.join('\n')}\n\n`;
+}
+
+// ---- Callout rendering ----
+
+function renderCallout(element: Y.XmlElement, depth: number): string {
+  const calloutType = (element.getAttribute('type') || 'note').toUpperCase();
+  const title = element.getAttribute('title') || '';
+  const titleSuffix = title ? ` ${title}` : '';
+  const inner = renderBlockChildren(element, depth + 1).replace(/\n\n$/, '');
+
+  if (!inner.trim()) return `> [!${calloutType}${titleSuffix}]\n\n`;
+
+  const prefixInner = inner
+    .split('\n')
+    .map((l) => `> ${l}`)
+    .join('\n');
+
+  return `> [!${calloutType}${titleSuffix}]\n${prefixInner}\n\n`;
+}
+
+// ---- Inline content rendering ----
+
+function renderInlineContent(element: Y.XmlFragment | Y.XmlElement): string {
+  let result = '';
+
+  for (let i = 0; i < element.length; i++) {
+    const child = element.get(i);
+
+    if (child instanceof Y.XmlText) {
+      result += renderDelta(child.toDelta() as DeltaSegment[]);
+    } else if (child instanceof Y.XmlElement) {
+      result += renderInlineElement(child);
+    }
+  }
+
+  return result;
+}
+
+function renderInlineElement(element: Y.XmlElement): string {
+  switch (element.nodeName) {
+    case 'image': {
+      const src = element.getAttribute('src') || '';
+      const alt = element.getAttribute('alt') || '';
+      const title = element.getAttribute('title') || '';
+      const titlePart = title ? ` "${title}"` : '';
+      return `![${alt}](${src}${titlePart})`;
+    }
+
+    case 'hardbreak':
+      return '\n';
+
+    case 'wikiLink': {
+      const path = element.getAttribute('path') || '';
+      const label = element.getAttribute('label') || '';
+      const heading = element.getAttribute('heading') || '';
+      // When imported via API, heading may be embedded in path (# suffix)
+      const resolvedHeading = heading || extractHeadingFromPath(path);
+      const resolvedPath =
+        resolvedHeading && heading === '' && !element.getAttribute('heading')
+          ? path.split('#')[0] || path
+          : path;
+      const target = resolvedHeading ? `${resolvedPath}#${resolvedHeading}` : resolvedPath;
+
+      if (label && label !== target) {
+        return `[[${target}|${label}]]`;
+      }
+      return `[[${target}]]`;
+    }
+
+    case 'tag': {
+      // Editor uses "name", API import uses "value" — check both
+      const name = element.getAttribute('name') || element.getAttribute('value') || '';
+      return name ? `#${name}` : '';
+    }
+
+    case 'math_inline': {
+      const value = element.getAttribute('value') || '';
+      return `$${value}$`;
+    }
+
+    case 'html': {
+      return element.getAttribute('value') || '';
+    }
+
+    case 'footnote_reference': {
+      const label = element.getAttribute('label') || '';
+      return `[^${label}]`;
+    }
+
+    default:
+      return renderInlineContent(element);
+  }
+}
+
+/**
+ * Extracts heading reference from a path string like "Page Name#Heading".
+ * Returns the heading part or empty string if no # separator is present.
+ */
+function extractHeadingFromPath(path: string): string {
+  const hashIndex = path.indexOf('#');
+  if (hashIndex === -1 || hashIndex === path.length - 1) return '';
+  return path.slice(hashIndex + 1);
+}
+
+// ---- Delta / mark processing ----
+
+function renderDelta(delta: DeltaSegment[]): string {
+  if (delta.length === 0) return '';
+
+  const hasLink = delta.some((seg) => seg.attributes && 'link' in seg.attributes);
+
+  if (!hasLink) {
+    return renderDeltaMarks(delta, new Set());
+  }
+
+  // Group consecutive segments by link href for [text](url) structure
+  return renderDeltaWithLinks(delta);
+}
+
+function renderDeltaWithLinks(delta: DeltaSegment[]): string {
+  const groups: { href: string | null; segments: DeltaSegment[] }[] = [];
+  let currentGroup: { href: string | null; segments: DeltaSegment[] } | null = null;
+
+  for (const seg of delta) {
+    const href = getLinkHref(seg);
+    if (!currentGroup || currentGroup.href !== href) {
+      currentGroup = { href, segments: [] };
+      groups.push(currentGroup);
+    }
+    currentGroup.segments.push(seg);
+  }
+
+  return groups
+    .map((group) => {
+      if (group.href) {
+        const inner = renderDeltaMarks(group.segments, new Set(['link']));
+        return `[${inner}](${group.href})`;
+      }
+      return renderDeltaMarks(group.segments, new Set(['link']));
+    })
+    .join('');
+}
+
+function getLinkHref(seg: DeltaSegment): string | null {
+  const linkAttr = seg.attributes?.link;
+  if (linkAttr && typeof linkAttr === 'object') {
+    const href = (linkAttr as Record<string, string>).href;
+    return href || null;
+  }
+  return null;
+}
+
+function renderDeltaMarks(segments: DeltaSegment[], excludeMarks: Set<string>): string {
+  let result = '';
+  const active: string[] = [];
+  const markOrder = MARK_ORDER as readonly string[];
+
+  for (const seg of segments) {
+    const segMarks = Object.keys(seg.attributes || {}).filter(
+      (m) => !excludeMarks.has(m) && MARK_DELIMITERS[m],
+    );
+
+    // Close marks that ended (reverse order for correct nesting)
+    for (let i = active.length - 1; i >= 0; i--) {
+      const mark = active[i] as string;
+      if (!segMarks.includes(mark)) {
+        const delim = MARK_DELIMITERS[mark];
+        if (delim) result += delim[1];
+        active.splice(i, 1);
+      }
+    }
+
+    // Open new marks (in canonical order)
+    const toOpen = segMarks.filter((m) => !active.includes(m));
+    toOpen.sort((a, b) => markOrder.indexOf(a) - markOrder.indexOf(b));
+    for (const mark of toOpen) {
+      result += MARK_DELIMITERS[mark]?.[0];
+      active.push(mark);
+    }
+
+    result += seg.insert;
+  }
+
+  // Close remaining marks (reverse order)
+  for (let i = active.length - 1; i >= 0; i--) {
+    result += MARK_DELIMITERS[active[i] as string]?.[1];
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Connection extraction (unchanged)
+// ---------------------------------------------------------------------------
 
 export function extractConnectionsFromYDoc(update: Uint8Array): ConnectionDraft[] {
   const doc = new Y.Doc();
   Y.applyUpdate(doc, update);
   const fragment = doc.getXmlFragment('prosemirror');
   return extractConnectionsFromXml(fragment);
-}
-
-function xmlElementToMarkdown(element: Y.XmlFragment | Y.XmlElement): string {
-  let markdown = '';
-
-  for (let i = 0; i < element.length; i++) {
-    const item = element.get(i);
-
-    if (item instanceof Y.XmlText) {
-      markdown += item.toString();
-    } else if (item instanceof Y.XmlElement) {
-      const type = item.nodeName;
-
-      switch (type) {
-        case 'paragraph':
-          markdown += `${xmlElementToMarkdown(item)}\n\n`;
-          break;
-        case 'heading': {
-          const level = Number.parseInt(item.getAttribute('level') || '1', 10);
-          markdown += `${'#'.repeat(level)} ${xmlElementToMarkdown(item)}\n\n`;
-          break;
-        }
-        case 'bullet_list':
-          markdown += `${xmlElementToMarkdown(item)}\n`;
-          break;
-        case 'ordered_list':
-          markdown += `${xmlElementToMarkdown(item)}\n`;
-          break;
-        case 'list_item':
-          markdown += `- ${xmlElementToMarkdown(item).trim()}\n`;
-          break;
-        case 'wikiLink': {
-          const path = item.getAttribute('path') || '';
-          const label = item.getAttribute('label') || '';
-          const heading = item.getAttribute('heading') || '';
-          const target = heading ? `${path}#${heading}` : path;
-          if (path === label) {
-            markdown += `[[${target}]]`;
-          } else {
-            markdown += `[[${target}|${label}]]`;
-          }
-          break;
-        }
-        case 'tag': {
-          const name = item.getAttribute('name') || item.getAttribute('value') || '';
-          markdown += name ? `#${name}` : '';
-          break;
-        }
-        case 'inlineCode':
-          markdown += `\`${xmlElementToMarkdown(item)}\``;
-          break;
-        case 'code_block':
-          markdown += `\`\`\`${item.getAttribute('language') || ''}\n${xmlElementToMarkdown(item)}\n\`\`\`\n\n`;
-          break;
-        default:
-          markdown += xmlElementToMarkdown(item);
-      }
-    }
-  }
-
-  return markdown;
 }
 
 function extractConnectionsFromXml(element: Y.XmlFragment | Y.XmlElement): ConnectionDraft[] {
@@ -183,6 +495,10 @@ function xmlElementPlainText(element: Y.XmlFragment | Y.XmlElement): string {
 
   return text;
 }
+
+// ---------------------------------------------------------------------------
+// Misc utilities (unchanged)
+// ---------------------------------------------------------------------------
 
 export function normalizePageSlug(value: string): string {
   return value.trim().toLowerCase();

--- a/packages/shared/src/utils/yjs-helpers.ts
+++ b/packages/shared/src/utils/yjs-helpers.ts
@@ -212,7 +212,7 @@ function renderCallout(element: Y.XmlElement, depth: number): string {
 
   const prefixInner = inner
     .split('\n')
-    .map((l) => `> ${l}`)
+    .map((l) => (l ? `> ${l}` : '>'))
     .join('\n');
 
   return `> [!${calloutType}${titleSuffix}]\n${prefixInner}\n\n`;

--- a/packages/shared/src/utils/yjs-helpers.unit.test.ts
+++ b/packages/shared/src/utils/yjs-helpers.unit.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import * as Y from 'yjs';
 import { extractConnectionsFromYDoc, yDocToMarkdown } from './yjs-helpers';
 
+// --------------------------------------------------------------------------
+// Helpers for building Yjs test documents
+// --------------------------------------------------------------------------
+
 function encodeFragment(children: Y.XmlElement[]): Uint8Array {
   const doc = new Y.Doc();
   const fragment = doc.getXmlFragment('prosemirror');
@@ -9,25 +13,381 @@ function encodeFragment(children: Y.XmlElement[]): Uint8Array {
   return Y.encodeStateAsUpdate(doc);
 }
 
-function paragraph(children: (Y.XmlElement | Y.XmlText)[]): Y.XmlElement {
-  const node = new Y.XmlElement('paragraph');
+function block(name: string, children: (Y.XmlElement | Y.XmlText)[]): Y.XmlElement {
+  const node = new Y.XmlElement(name);
   node.push(children);
   return node;
+}
+
+function blockWithAttrs(
+  name: string,
+  attrs: Record<string, string>,
+  children: (Y.XmlElement | Y.XmlText)[],
+): Y.XmlElement {
+  const node = block(name, children);
+  for (const [k, v] of Object.entries(attrs)) {
+    node.setAttribute(k, v);
+  }
+  return node;
+}
+
+function inlineEl(name: string, attrs: Record<string, string>): Y.XmlElement {
+  return blockWithAttrs(name, attrs, []);
 }
 
 function text(value: string): Y.XmlText {
   return new Y.XmlText(value);
 }
 
-describe('yjs helpers', () => {
-  it('serializes tag nodes to markdown', () => {
-    const tag = new Y.XmlElement('tag');
-    tag.setAttribute('name', 'Project');
-    const update = encodeFragment([paragraph([text('Track '), tag])]);
+function formattedText(value: string, formats: Record<string, unknown>): Y.XmlText {
+  const t = new Y.XmlText(value);
+  t.format(0, value.length, formats);
+  return t;
+}
 
-    expect(yDocToMarkdown(update)).toBe('Track #Project\n\n');
+function multiFormattedText(
+  segments: { text: string; formats?: Record<string, unknown> }[],
+): Y.XmlText[] {
+  return segments.map((s) =>
+    s.formats ? formattedText(s.text, s.formats) : new Y.XmlText(s.text),
+  );
+}
+
+// Marks use the y-prosemirror format (object values) since that's what the
+// editor produces. The API import uses booleans but the serializer handles both.
+const BOLD = { strong: {} };
+const ITALIC = { emphasis: {} };
+const CODE = { inlineCode: {} };
+const STRIKE = { strike_through: {} };
+const link = (href: string) => ({ link: { href, title: '' } });
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe('yDocToMarkdown', () => {
+  it('converts a plain paragraph', () => {
+    const update = encodeFragment([block('paragraph', [text('Hello world')])]);
+    expect(yDocToMarkdown(update)).toBe('Hello world\n\n');
   });
 
+  it('converts a heading', () => {
+    const update = encodeFragment([blockWithAttrs('heading', { level: '1' }, [text('Title')])]);
+    expect(yDocToMarkdown(update)).toBe('# Title\n\n');
+  });
+
+  it('converts all heading levels', () => {
+    for (let level = 1; level <= 6; level++) {
+      const update = encodeFragment([
+        blockWithAttrs('heading', { level: String(level) }, [text(`H${level}`)]),
+      ]);
+      expect(yDocToMarkdown(update)).toBe(`${'#'.repeat(level)} H${level}\n\n`);
+    }
+  });
+
+  it('converts bold text', () => {
+    const update = encodeFragment([block('paragraph', [formattedText('bold text', BOLD)])]);
+    expect(yDocToMarkdown(update)).toBe('**bold text**\n\n');
+  });
+
+  it('converts italic text', () => {
+    const update = encodeFragment([block('paragraph', [formattedText('italic text', ITALIC)])]);
+    expect(yDocToMarkdown(update)).toBe('*italic text*\n\n');
+  });
+
+  it('converts strikethrough text', () => {
+    const update = encodeFragment([block('paragraph', [formattedText('struck', STRIKE)])]);
+    expect(yDocToMarkdown(update)).toBe('~~struck~~\n\n');
+  });
+
+  it('converts inline code', () => {
+    const update = encodeFragment([block('paragraph', [formattedText('code', CODE)])]);
+    expect(yDocToMarkdown(update)).toBe('`code`\n\n');
+  });
+
+  it('converts a link', () => {
+    const update = encodeFragment([
+      block('paragraph', [formattedText('click here', link('https://example.com'))]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('[click here](https://example.com)\n\n');
+  });
+
+  it('converts bold + italic combined', () => {
+    // bold italic text
+    const t = new Y.XmlText('bold and italic');
+    t.format(0, 16, BOLD);
+    t.format(5, 11, ITALIC); // "and italic" is also italic
+    const update = encodeFragment([block('paragraph', [t])]);
+    const result = yDocToMarkdown(update);
+    // The exact output depends on delta segmentation but both marks must be present
+    expect(result).toContain('**');
+    expect(result).toContain('*');
+  });
+
+  it('converts a mix of plain and bold text', () => {
+    const t1 = text('Plain ');
+    const t2 = formattedText('bold', BOLD);
+    const t3 = text(' text');
+    const update = encodeFragment([block('paragraph', [t1, t2, t3])]);
+    expect(yDocToMarkdown(update)).toBe('Plain **bold** text\n\n');
+  });
+
+  it('converts a link with bold inside', () => {
+    const boldPart = formattedText('bold link', { ...BOLD, ...link('https://example.com') });
+    const update = encodeFragment([block('paragraph', [boldPart])]);
+    const result = yDocToMarkdown(update);
+    // Should contain the URL and bold markers
+    expect(result).toContain('https://example.com');
+    expect(result).toContain('**');
+    expect(result).toMatch(/\]\(https:\/\/example\.com\)/);
+  });
+
+  it('converts a code block without language', () => {
+    const update = encodeFragment([blockWithAttrs('code_block', {}, [text('const x = 1;')])]);
+    expect(yDocToMarkdown(update)).toBe('```\nconst x = 1;\n```\n\n');
+  });
+
+  it('converts a code block with language', () => {
+    const update = encodeFragment([
+      blockWithAttrs('code_block', { language: 'javascript' }, [text('const x = 1;')]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('```javascript\nconst x = 1;\n```\n\n');
+  });
+
+  it('converts a blockquote with single paragraph', () => {
+    const update = encodeFragment([
+      block('blockquote', [block('paragraph', [text('Cited text')])]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('> Cited text\n\n');
+  });
+
+  it('converts a blockquote with multiple paragraphs', () => {
+    const update = encodeFragment([
+      block('blockquote', [
+        block('paragraph', [text('First para')]),
+        block('paragraph', [text('Second para')]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('> First para\n>\n> Second para\n\n');
+  });
+
+  it('converts a bullet list', () => {
+    const update = encodeFragment([
+      block('bullet_list', [
+        block('list_item', [block('paragraph', [text('Item A')])]),
+        block('list_item', [block('paragraph', [text('Item B')])]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('- Item A\n- Item B\n');
+  });
+
+  it('converts an ordered list', () => {
+    const update = encodeFragment([
+      block('ordered_list', [
+        block('list_item', [block('paragraph', [text('First')])]),
+        block('list_item', [block('paragraph', [text('Second')])]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('1. First\n2. Second\n');
+  });
+
+  it('converts a task list (checked and unchecked)', () => {
+    const update = encodeFragment([
+      block('bullet_list', [
+        blockWithAttrs('list_item', { checked: 'true' }, [block('paragraph', [text('Done')])]),
+        blockWithAttrs('list_item', { checked: 'false' }, [block('paragraph', [text('Todo')])]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('- [x] Done\n- [ ] Todo\n');
+  });
+
+  it('converts a nested bullet list', () => {
+    const update = encodeFragment([
+      block('bullet_list', [
+        block('list_item', [
+          block('paragraph', [text('Top')]),
+          block('bullet_list', [block('list_item', [block('paragraph', [text('Nested')])])]),
+        ]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('- Top\n  - Nested\n');
+  });
+
+  it('converts a table', () => {
+    const update = encodeFragment([
+      block('table', [
+        block('table_header_row', [
+          blockWithAttrs('table_header', {}, [block('paragraph', [text('Name')])]),
+          blockWithAttrs('table_header', {}, [block('paragraph', [text('Age')])]),
+        ]),
+        block('table_row', [
+          blockWithAttrs('table_cell', {}, [block('paragraph', [text('Alice')])]),
+          blockWithAttrs('table_cell', {}, [block('paragraph', [text('30')])]),
+        ]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('| Name | Age |\n| --- | --- |\n| Alice | 30 |\n\n');
+  });
+
+  it('converts a table with alignment', () => {
+    const update = encodeFragment([
+      block('table', [
+        block('table_header_row', [
+          blockWithAttrs('table_header', { alignment: 'left' }, [
+            block('paragraph', [text('Left')]),
+          ]),
+          blockWithAttrs('table_header', { alignment: 'center' }, [
+            block('paragraph', [text('Center')]),
+          ]),
+          blockWithAttrs('table_header', { alignment: 'right' }, [
+            block('paragraph', [text('Right')]),
+          ]),
+        ]),
+        block('table_row', [
+          blockWithAttrs('table_cell', {}, [block('paragraph', [text('a')])]),
+          blockWithAttrs('table_cell', {}, [block('paragraph', [text('b')])]),
+          blockWithAttrs('table_cell', {}, [block('paragraph', [text('c')])]),
+        ]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe(
+      '| Left | Center | Right |\n| :--- | :---: | ---: |\n| a | b | c |\n\n',
+    );
+  });
+
+  it('converts a wiki link without label', () => {
+    const update = encodeFragment([
+      block('paragraph', [inlineEl('wikiLink', { path: 'Page Name', label: 'Page Name' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('[[Page Name]]\n\n');
+  });
+
+  it('converts a wiki link with label', () => {
+    const update = encodeFragment([
+      block('paragraph', [inlineEl('wikiLink', { path: 'Long Page', label: 'Link' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('[[Long Page|Link]]\n\n');
+  });
+
+  it('converts a wiki link with heading', () => {
+    const update = encodeFragment([
+      block('paragraph', [
+        inlineEl('wikiLink', { path: 'Page', heading: 'Section', label: 'Page#Section' }),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('[[Page#Section]]\n\n');
+  });
+
+  it('converts a wiki link with embedded heading in path (API import format)', () => {
+    const update = encodeFragment([
+      block('paragraph', [inlineEl('wikiLink', { path: 'Page#Section', label: 'Page#Section' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('[[Page#Section]]\n\n');
+  });
+
+  it('converts a tag (name attribute)', () => {
+    const update = encodeFragment([
+      block('paragraph', [text('Tag: '), inlineEl('tag', { name: 'project' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('Tag: #project\n\n');
+  });
+
+  it('converts a tag (value attribute — API import format)', () => {
+    const update = encodeFragment([
+      block('paragraph', [text('Tag: '), inlineEl('tag', { value: 'urgent' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('Tag: #urgent\n\n');
+  });
+
+  it('converts inline math', () => {
+    const update = encodeFragment([
+      block('paragraph', [text('Math: '), inlineEl('math_inline', { value: 'E=mc^2' })]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('Math: $E=mc^2$\n\n');
+  });
+
+  it('converts an image', () => {
+    const update = encodeFragment([
+      block('paragraph', [
+        inlineEl('image', { src: 'https://example.com/pic.png', alt: 'Example', title: '' }),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('![Example](https://example.com/pic.png)\n\n');
+  });
+
+  it('converts an image with title', () => {
+    const update = encodeFragment([
+      block('paragraph', [
+        inlineEl('image', {
+          src: 'https://example.com/pic.png',
+          alt: 'Example',
+          title: 'A photo',
+        }),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('![Example](https://example.com/pic.png "A photo")\n\n');
+  });
+
+  it('converts a horizontal rule', () => {
+    const update = encodeFragment([block('hr', [])]);
+    expect(yDocToMarkdown(update)).toBe('---\n\n');
+  });
+
+  it('converts a hard break', () => {
+    const update = encodeFragment([
+      block('paragraph', [text('Line 1'), block('hardbreak', []), text('Line 2')]),
+    ]);
+    const result = yDocToMarkdown(update);
+    expect(result).toContain('Line 1');
+    expect(result).toContain('Line 2');
+  });
+
+  it('converts a callout', () => {
+    const update = encodeFragment([
+      blockWithAttrs('callout', { type: 'warning' }, [block('paragraph', [text('Be careful')])]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('> [!WARNING]\n> Be careful\n\n');
+  });
+
+  it('converts a callout with title', () => {
+    const update = encodeFragment([
+      blockWithAttrs('callout', { type: 'info', title: 'Note' }, [
+        block('paragraph', [text('Something to note')]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('> [!INFO Note]\n> Something to note\n\n');
+  });
+
+  it('converts mixed content: heading + paragraph + list', () => {
+    const update = encodeFragment([
+      blockWithAttrs('heading', { level: '2' }, [text('Section')]),
+      block('paragraph', [text('Some text with '), formattedText('emphasis', ITALIC)]),
+      block('bullet_list', [
+        block('list_item', [block('paragraph', [text('One')])]),
+        block('list_item', [block('paragraph', [text('Two')])]),
+      ]),
+    ]);
+    const md = yDocToMarkdown(update);
+    expect(md).toContain('## Section');
+    expect(md).toContain('Some text with *emphasis*');
+    expect(md).toContain('- One\n- Two');
+  });
+
+  it('returns empty string for empty document', () => {
+    const doc = new Y.Doc();
+    const update = Y.encodeStateAsUpdate(doc);
+    expect(yDocToMarkdown(update)).toBe('');
+  });
+
+  it('handles a document with only the prosemirror fragment and no children', () => {
+    const doc = new Y.Doc();
+    doc.getXmlFragment('prosemirror');
+    const update = Y.encodeStateAsUpdate(doc);
+    expect(yDocToMarkdown(update)).toBe('');
+  });
+});
+
+describe('extractConnectionsFromYDoc', () => {
   it('extracts page and tag connections from Yjs documents', () => {
     const link = new Y.XmlElement('wikiLink');
     link.setAttribute('targetId', '11111111-1111-1111-1111-111111111111');
@@ -37,7 +397,7 @@ describe('yjs helpers', () => {
     const tag = new Y.XmlElement('tag');
     tag.setAttribute('name', 'Project');
 
-    const update = encodeFragment([paragraph([text('See '), link, text(' for '), tag])]);
+    const update = encodeFragment([block('paragraph', [text('See '), link, text(' for '), tag])]);
 
     expect(extractConnectionsFromYDoc(update)).toEqual([
       {

--- a/packages/shared/src/utils/yjs-helpers.unit.test.ts
+++ b/packages/shared/src/utils/yjs-helpers.unit.test.ts
@@ -45,14 +45,6 @@ function formattedText(value: string, formats: Record<string, unknown>): Y.XmlTe
   return t;
 }
 
-function multiFormattedText(
-  segments: { text: string; formats?: Record<string, unknown> }[],
-): Y.XmlText[] {
-  return segments.map((s) =>
-    s.formats ? formattedText(s.text, s.formats) : new Y.XmlText(s.text),
-  );
-}
-
 // Marks use the y-prosemirror format (object values) since that's what the
 // editor produces. The API import uses booleans but the serializer handles both.
 const BOLD = { strong: {} };
@@ -356,6 +348,16 @@ describe('yDocToMarkdown', () => {
       ]),
     ]);
     expect(yDocToMarkdown(update)).toBe('> [!INFO Note]\n> Something to note\n\n');
+  });
+
+  it('converts a multi-paragraph callout with empty lines between paragraphs', () => {
+    const update = encodeFragment([
+      blockWithAttrs('callout', { type: 'tip' }, [
+        block('paragraph', [text('First para')]),
+        block('paragraph', [text('Second para')]),
+      ]),
+    ]);
+    expect(yDocToMarkdown(update)).toBe('> [!TIP]\n> First para\n>\n> Second para\n\n');
   });
 
   it('converts mixed content: heading + paragraph + list', () => {


### PR DESCRIPTION
## Summary

- Rewrites the Yjs-to-markdown serializer to properly traverse the prosemirror XML tree instead of naively decoding binary as UTF-8 (root cause of #58)
- Adds image extraction pipeline: scans exported markdown, downloads server images from disk, decodes base64 data URIs, bundles into `assets/` folder with relative path rewrites
- Adds YAML frontmatter support for page properties and icons
- Fixes uploads path resolution to be cwd-independent (`__dirname`-based)
- Handles edge cases: code block masking, title preservation, SVG base64, hidden filename rejection, SHA-256 deduplication

## Changes

| File | What |
|------|------|
| `packages/shared/src/utils/yjs-helpers.ts` | Full serializer rewrite (~500 lines) with handlers for all block/inline types, formatting marks, wiki links, tags, math |
| `packages/api/src/utils/export-helpers.ts` | New file: `extractImages()`, `serializeFrontmatter()`, `pageToMarkdown()` |
| `packages/api/src/routes/export.ts` | Workspace export wired to new pipeline, bundles `assets/` in ZIP |
| `packages/api/src/routes/pages.ts` | Single-page export returns ZIP when images exist, markdown otherwise |
| `packages/api/src/routes/uploads.ts` | Fixes `path.resolve('uploads')` to be cwd-independent |

## Tests

- 20 new unit tests for image extraction
- All existing tests pass (138 unit + 39 integration)
- TypeScript clean, biome clean

Closes #58