### PR TITLE
fix(web): prevent nested-list duplication and fix Milkdown list-item attr rendering

### DIFF
--- a/packages/web/src/components/editor/MilkdownEditor.tsx
+++ b/packages/web/src/components/editor/MilkdownEditor.tsx
@@ -50,7 +50,7 @@ import * as Y from 'yjs';
 import { FloatingToolbar } from './FloatingToolbar';
 import { SlashMenu } from './SlashMenu';
 import { WikiLinkSuggestions } from './WikiLinkSuggestions';
-import { hasTaskListAncestor, switchListType, unwrapList, wrapBlocksInList } from './listCommands';
+import { getClosestListType, switchListType, unwrapList, wrapBlocksInList } from './listCommands';
 
 interface MilkdownEditorProps {
   pageId: string;
@@ -183,7 +183,7 @@ export function MilkdownEditor({
         const marks = schema.marks;
         const nodes = schema.nodes;
 
-        const isTaskListItem = hasTaskListAncestor(state);
+        const closestListDisplayType = getClosestListType(state);
 
         setActiveStates({
           isBoldActive: hasMark(state, marks.strong),
@@ -198,9 +198,9 @@ export function MilkdownEditor({
           isH4Active: hasBlockType(state, nodes.heading, { level: 4 }),
           isH5Active: hasBlockType(state, nodes.heading, { level: 5 }),
           isH6Active: hasBlockType(state, nodes.heading, { level: 6 }),
-          isBulletListActive: hasParentBlockType(state, nodes.bullet_list) && !isTaskListItem,
-          isOrderedListActive: hasParentBlockType(state, nodes.ordered_list),
-          isTaskListActive: isTaskListItem,
+          isBulletListActive: closestListDisplayType === 'bullet',
+          isOrderedListActive: closestListDisplayType === 'ordered',
+          isTaskListActive: closestListDisplayType === 'task',
           isInTableActive: isInTable(state),
         });
       });
@@ -584,15 +584,17 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const bulletListType = state.schema.nodes.bullet_list;
-      const orderedListType = state.schema.nodes.ordered_list;
       if (!bulletListType || !dispatch) return;
 
-      if (hasTaskListAncestor(state)) {
-        // Convert checklist to regular bullet list (clear checked attr)
+      // Base decisions on the closest (innermost) list, not any ancestor.
+      // This ensures ordered lists nested inside bullets convert correctly
+      // instead of accidentally unwrapping the inner list.
+      const closestType = getClosestListType(state);
+      if (closestType === 'task') {
         switchListType(state, bulletListType, dispatch, {});
-      } else if (hasParentBlockType(state, bulletListType)) {
+      } else if (closestType === 'bullet') {
         unwrapList(state, dispatch);
-      } else if (hasParentBlockType(state, orderedListType)) {
+      } else if (closestType === 'ordered') {
         switchListType(state, bulletListType, dispatch);
       } else {
         wrapBlocksInList(state, bulletListType, dispatch);
@@ -615,10 +617,10 @@ export function MilkdownEditor({
       if (!view) return;
       const { state, dispatch } = view;
       const orderedListType = state.schema.nodes.ordered_list;
-      const bulletListType = state.schema.nodes.bullet_list;
       if (!orderedListType || !dispatch) return;
 
-      if (hasParentBlockType(state, orderedListType)) {
+      const closestType = getClosestListType(state);
+      if (closestType === 'ordered') {
         // Check if the selection also contains top-level blocks outside
         // any list. If so, rebuild all content into one list.
         const { from, to } = state.selection;
@@ -628,8 +630,6 @@ export function MilkdownEditor({
           state.doc.nodesBetween(from, to, (node, pos) => {
             if (!node.isBlock || node.type.name === 'doc') return;
             const $pos = state.doc.resolve(pos);
-            // Only count nodes directly inside the document (depth 1)
-            // as "non-list" — content inside list items shouldn't count.
             if ($pos.depth <= 1 && node.type !== listItemType && node.type !== orderedListType) {
               hasNonList = true;
             }
@@ -640,10 +640,9 @@ export function MilkdownEditor({
         } else {
           wrapBlocksInList(state, orderedListType, dispatch);
         }
-      } else if (hasTaskListAncestor(state)) {
-        // Convert checklist to numbered list
+      } else if (closestType === 'task') {
         switchListType(state, orderedListType, dispatch, {});
-      } else if (hasParentBlockType(state, bulletListType) && !hasTaskListAncestor(state)) {
+      } else if (closestType === 'bullet') {
         switchListType(state, orderedListType, dispatch);
       } else {
         wrapBlocksInList(state, orderedListType, dispatch);
@@ -670,12 +669,10 @@ export function MilkdownEditor({
       if (!bulletListType || !listItemType || !dispatch) return;
 
       const taskAttrs = { checked: false };
-      if (hasTaskListAncestor(state)) {
+      const closestType = getClosestListType(state);
+      if (closestType === 'task') {
         unwrapList(state, dispatch);
-      } else if (
-        hasParentBlockType(state, bulletListType) ||
-        hasParentBlockType(state, state.schema.nodes.ordered_list)
-      ) {
+      } else if (closestType === 'bullet' || closestType === 'ordered') {
         switchListType(state, bulletListType, dispatch, taskAttrs);
       } else {
         wrapBlocksInList(state, bulletListType, dispatch, taskAttrs);

--- a/packages/web/src/components/editor/listCommands.test.ts
+++ b/packages/web/src/components/editor/listCommands.test.ts
@@ -4,8 +4,10 @@ import { EditorState, TextSelection } from 'prosemirror-state';
 import { describe, expect, it } from 'vitest';
 import {
   blockRange,
-  collectListItems,
+  collectDirectListItems,
+  collectListItemsInRange,
   findParentList,
+  getClosestListType,
   hasTaskListAncestor,
   switchListType,
   unwrapList,
@@ -51,9 +53,13 @@ function p(text: string) {
   return schema.node('paragraph', null, schema.text(text));
 }
 
-function li(content: string, checked: 'task' | null = null) {
+function li(
+  content: string,
+  checked: 'task' | null = null,
+  ...children: ReturnType<typeof schema.node>[]
+) {
   const attrs = checked === 'task' ? { checked: false } : null;
-  return schema.node('list_item', attrs, p(content));
+  return schema.node('list_item', attrs, [p(content), ...children]);
 }
 
 function ul(...items: ReturnType<typeof li>[]) {
@@ -116,6 +122,18 @@ function nodeTexts(state: EditorState, typeName: string): string[] {
   return texts;
 }
 
+// ---- Reusable helpers ----
+
+function posInListItem(docNode: ReturnType<typeof doc>, text: string): number {
+  let pos = -1;
+  docNode.descendants((node, p) => {
+    if (node.type.name === 'paragraph' && node.textContent === text) {
+      pos = p + 1;
+    }
+  });
+  return pos;
+}
+
 // ============================================================
 //  hasTaskListAncestor
 // ============================================================
@@ -169,13 +187,13 @@ describe('findParentList', () => {
 });
 
 // ============================================================
-//  collectListItems
+//  collectListItemsInRange
 // ============================================================
-describe('collectListItems', () => {
+describe('collectListItemsInRange', () => {
   it('returns all list items within a range', () => {
     const myDoc = doc(ul(li('a'), li('b'), li('c')));
     const state = stateWithDoc(myDoc);
-    const items = collectListItems(state.doc, 1, state.doc.content.size);
+    const items = collectListItemsInRange(state.doc, 1, state.doc.content.size);
     expect(items).toHaveLength(3);
     expect(items.map((i) => i.node.textContent)).toEqual(['a', 'b', 'c']);
   });
@@ -183,7 +201,6 @@ describe('collectListItems', () => {
   it('returns items intersecting a partial range', () => {
     const myDoc = doc(ul(li('a'), li('b'), li('c')));
     const state = stateWithDoc(myDoc);
-    // Find the "b" list item and its exact node size
     let bPos = -1;
     let bSize = -1;
     myDoc.descendants((node, pos) => {
@@ -193,10 +210,66 @@ describe('collectListItems', () => {
       }
     });
     expect(bPos).not.toBe(-1);
-    // Range exactly matching the item's boundaries
-    const items = collectListItems(state.doc, bPos, bPos + bSize);
+    const items = collectListItemsInRange(state.doc, bPos, bPos + bSize);
     expect(items).toHaveLength(1);
     expect(items[0]?.node.textContent).toBe('b');
+  });
+
+  it('returns items at ALL depths including nested', () => {
+    const myDoc = doc(ul(li('Outer A', null, ul(li('Inner 1'), li('Inner 2'))), li('Outer B')));
+    const state = stateWithDoc(myDoc);
+    const items = collectListItemsInRange(state.doc, 1, state.doc.content.size);
+    // Should find all 4 items (Outer A, Inner 1, Inner 2, Outer B)
+    // because this function traverses ALL descendants
+    expect(items).toHaveLength(4);
+    // node.textContent includes nested children's text — Outer A's item
+    // contains "Inner 1" and "Inner 2" text from its nested sub-list
+    const textContents = items.map((i) => i.node.textContent);
+    expect(textContents[0]).toContain('Outer A');
+    expect(textContents).toContain('Inner 1');
+    expect(textContents).toContain('Inner 2');
+    expect(textContents).toContain('Outer B');
+  });
+});
+
+// ============================================================
+//  collectDirectListItems
+// ============================================================
+describe('collectDirectListItems', () => {
+  it('returns only direct children of a flat list', () => {
+    const myDoc = doc(ul(li('a'), li('b'), li('c')));
+    const listNode = myDoc.content.child(0);
+    // First child starts at position 1 (after the list opening)
+    const items = collectDirectListItems(listNode, 0);
+    expect(items).toHaveLength(3);
+    expect(items.map((i) => i.node.textContent)).toEqual(['a', 'b', 'c']);
+    // Positions should be sequential: list starts at 0, first child at 1
+    expect(items[0]?.pos).toBe(1);
+  });
+
+  it('returns only direct children excluding nested items', () => {
+    // Critical: collectDirectListItems must NOT include nested items
+    const nested = ul(li('Inner 1'), li('Inner 2'));
+    const myDoc = doc(ul(li('Outer A', null, nested), li('Outer B')));
+    const listNode = myDoc.content.child(0); // outer bullet_list
+    const items = collectDirectListItems(listNode, 0);
+    expect(items).toHaveLength(2);
+    const textContents = items.map((i) => i.node.textContent);
+    expect(textContents[0]).toContain('Outer A');
+    expect(textContents[1]).toBe('Outer B');
+  });
+
+  it('computes correct positions for direct children', () => {
+    const nested = ul(li('Inner'));
+    // Outer A has: paragraph + nested ul → larger nodeSize than Outer B
+    const myDoc = doc(ul(li('Outer A', null, nested), li('Outer B')));
+    const listNode = myDoc.content.child(0);
+    const items = collectDirectListItems(listNode, 0);
+    expect(items).toHaveLength(2);
+    // Outer B should start after Outer A's full nodeSize
+    const item0 = items[0];
+    const item1 = items[1];
+    expect(item1?.pos).toBe((item0?.pos ?? 0) + (item0?.node.nodeSize ?? 0));
   });
 });
 
@@ -225,7 +298,86 @@ describe('blockRange', () => {
 });
 
 // ============================================================
-//  unwrapList  —  Regression tests for Bug 1
+//  switchListType  —  Nested-list scenarios
+// ============================================================
+describe('switchListType with nested lists', () => {
+  function nestedDoc() {
+    return doc(ul(li('Outer A', null, ul(li('Inner 1'), li('Inner 2'))), li('Outer B')));
+  }
+
+  it('switches inner list type without affecting outer list', () => {
+    const myDoc = nestedDoc();
+    const innerPos = posInListItem(myDoc, 'Inner 1');
+    expect(innerPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, innerPos);
+    const orderedList = schema.nodes.ordered_list;
+
+    const newState = applyCommand(state, (st, dispatch) =>
+      switchListType(st, orderedList, dispatch),
+    );
+
+    // Inner list should now be ordered
+    const orderedLists = new Array<{ order?: number }>();
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'ordered_list') orderedLists.push({ order: node.attrs.order });
+    });
+    expect(orderedLists).toHaveLength(1);
+    expect(countNodes(newState, 'bullet_list')).toBe(1);
+    expect(nodeTexts(newState, 'list_item')).toContain('Inner 1');
+    expect(nodeTexts(newState, 'list_item')).toContain('Inner 2');
+  });
+
+  it('switches outer list type without flattening inner list', () => {
+    const myDoc = nestedDoc();
+    const outerBPos = posInListItem(myDoc, 'Outer B');
+    expect(outerBPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, outerBPos);
+    const orderedList = schema.nodes.ordered_list;
+
+    const newState = applyCommand(state, (st, dispatch) =>
+      switchListType(st, orderedList, dispatch),
+    );
+
+    expect(countNodes(newState, 'ordered_list')).toBe(1);
+    expect(countNodes(newState, 'bullet_list')).toBe(1);
+    expect(countNodes(newState, 'list_item')).toBe(4); // Outer A + Inner 1 + Inner 2 + Outer B
+    // Inner list should still have 2 items
+    let innerItemCount = 0;
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'bullet_list') {
+        node.descendants((child) => {
+          if (child.type.name === 'list_item') innerItemCount++;
+        });
+      }
+    });
+    expect(innerItemCount).toBe(2);
+  });
+
+  it('converts task list nested inside bullet list', () => {
+    const myDoc = doc(ul(li('Regular'), li('Task', 'task', ul(li('Nested Task', 'task')))));
+    const taskPos = posInListItem(myDoc, 'Task');
+    expect(taskPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, taskPos);
+    const orderedList = schema.nodes.ordered_list;
+
+    const newState = applyCommand(state, (st, dispatch) =>
+      switchListType(st, orderedList, dispatch, {}),
+    );
+
+    expect(countNodes(newState, 'ordered_list')).toBe(1);
+    // Nested task list item should still have checked state
+    let nestedChecked = false;
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'list_item' && node.attrs.checked === false) {
+        nestedChecked = true;
+      }
+    });
+    expect(nestedChecked).toBe(true);
+  });
+});
+
+// ============================================================
+//  switchListType  —  Regression tests for Bug 7
 // ============================================================
 describe('unwrapList', () => {
   it('unwraps only the selected item in a multi-item list (collapsed selection)', () => {
@@ -340,6 +492,57 @@ describe('unwrapList', () => {
     expect(lists).toHaveLength(2);
     expect(lists[0]).toEqual({ order: 3, texts: ['First'] });
     expect(lists[1]).toEqual({ order: 4, texts: ['Third'] });
+  });
+});
+
+// ============================================================
+//  getClosestListType
+// ============================================================
+describe('getClosestListType', () => {
+  it('returns null when not in a list', () => {
+    const state = stateWithDoc(doc(p('text')), 3);
+    expect(getClosestListType(state)).toBeNull();
+  });
+
+  it('returns bullet for flat bullet list', () => {
+    const state = stateWithDoc(doc(ul(li('item'))), 3);
+    expect(getClosestListType(state)).toBe('bullet');
+  });
+
+  it('returns ordered for flat ordered list', () => {
+    const state = stateWithDoc(doc(ol(li('item'))), 3);
+    expect(getClosestListType(state)).toBe('ordered');
+  });
+
+  it('returns task for task list item', () => {
+    const state = stateWithDoc(doc(ul(li('task', 'task'))), 3);
+    expect(getClosestListType(state)).toBe('task');
+  });
+
+  it('returns inner list type in nested context (bullet > ordered)', () => {
+    const myDoc = doc(ul(li('Outer', null, ol(li('Inner')))));
+    let innerPos = -1;
+    myDoc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.textContent === 'Inner') {
+        innerPos = pos + 1;
+      }
+    });
+    expect(innerPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, innerPos);
+    expect(getClosestListType(state)).toBe('ordered');
+  });
+
+  it('returns inner list type in nested context (ordered > bullet)', () => {
+    const myDoc = doc(ol(li('Outer', null, ul(li('Inner')))));
+    let innerPos = -1;
+    myDoc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.textContent === 'Inner') {
+        innerPos = pos + 1;
+      }
+    });
+    expect(innerPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, innerPos);
+    expect(getClosestListType(state)).toBe('bullet');
   });
 });
 
@@ -489,7 +692,103 @@ describe('wrapBlocksInList', () => {
 });
 
 // ============================================================
-//  switchListType  —  Regression tests for Bug 7
+//  unwrapList  —  Nested-list scenarios
+// ============================================================
+describe('unwrapList with nested lists', () => {
+  function nestedDoc() {
+    return doc(ul(li('Outer A', null, ul(li('Inner 1'), li('Inner 2'))), li('Outer B')));
+  }
+
+  it('unwraps innermost item without affecting outer structure', () => {
+    const myDoc = nestedDoc();
+    const innerStart = posInListItem(myDoc, 'Inner 1');
+    expect(innerStart).not.toBe(-1);
+    const state = stateWithDoc(myDoc, innerStart);
+
+    const newState = applyCommand(state, unwrapList);
+
+    // "Inner 1" should now be a paragraph (removed from inner list)
+    expect(nodeTexts(newState, 'paragraph')).toContain('Inner 1');
+    // "Inner 2" should still be a list item in the inner list
+    expect(nodeTexts(newState, 'list_item')).toContain('Inner 2');
+    // Outer structure should remain intact
+    expect(countNodes(newState, 'bullet_list')).toBe(2); // outer + inner
+  });
+
+  it('unwraps outermost item preserving nested content', () => {
+    const myDoc = nestedDoc();
+    const outerStart = posInListItem(myDoc, 'Outer A');
+    expect(outerStart).not.toBe(-1);
+    const state = stateWithDoc(myDoc, outerStart);
+
+    const newState = applyCommand(state, unwrapList);
+
+    expect(nodeTexts(newState, 'paragraph')).toContain('Outer A');
+    expect(nodeTexts(newState, 'list_item')).toEqual(['Inner 1', 'Inner 2', 'Outer B']);
+    expect(countNodes(newState, 'bullet_list')).toBe(2);
+  });
+
+  it('does not duplicate nested items when unwrapping a sibling', () => {
+    const myDoc = nestedDoc();
+    const outerBPos = posInListItem(myDoc, 'Outer B');
+    expect(outerBPos).not.toBe(-1);
+    const state = stateWithDoc(myDoc, outerBPos);
+
+    const newState = applyCommand(state, unwrapList);
+
+    expect(nodeTexts(newState, 'paragraph')).toContain('Outer B');
+    const innerItems = nodeTexts(newState, 'list_item');
+    expect(innerItems.filter((t) => t === 'Inner 1')).toHaveLength(1);
+    expect(innerItems.filter((t) => t === 'Inner 2')).toHaveLength(1);
+    expect(countNodes(newState, 'list_item')).toBe(3);
+  });
+
+  it('preserves three-level nesting structure', () => {
+    const triple = doc(ul(li('A', null, ul(li('B', null, ul(li('C')))))));
+    const cPos = posInListItem(triple, 'C');
+    expect(cPos).not.toBe(-1);
+    const state = stateWithDoc(triple, cPos);
+
+    const newState = applyCommand(state, unwrapList);
+
+    expect(nodeTexts(newState, 'paragraph')).toContain('C');
+    // B and A remain as list_items (their textContent includes descendants)
+    expect(nodeTexts(newState, 'list_item')).toHaveLength(2);
+    // The inner list (containing C) was removed — only outer + middle remain
+    expect(countNodes(newState, 'bullet_list')).toBe(2);
+  });
+
+  it('unwraps multiple direct items when selection spans them (no nested duplication)', () => {
+    const myDoc = doc(ul(li('First'), li('Second', null, ul(li('Nested'))), li('Third')));
+    // Select from start of First's paragraph to end of Third's paragraph
+    const firstPara = posInListItem(myDoc, 'First');
+    let thirdParaEnd = -1;
+    myDoc.descendants((node, pos) => {
+      if (node.type.name === 'paragraph' && node.textContent === 'Third') {
+        thirdParaEnd = pos + node.nodeSize;
+      }
+    });
+    expect(firstPara).not.toBe(-1);
+    expect(thirdParaEnd).not.toBe(-1);
+
+    // Use a text selection that spans from First paragraph to end of Third paragraph
+    const state = EditorState.create({
+      schema,
+      doc: myDoc,
+      selection: TextSelection.create(myDoc, firstPara - 1, thirdParaEnd),
+    });
+    const newState = applyCommand(state, unwrapList);
+
+    expect(nodeTexts(newState, 'paragraph')).toContain('First');
+    expect(nodeTexts(newState, 'paragraph')).toContain('Second');
+    expect(nodeTexts(newState, 'paragraph')).toContain('Third');
+    expect(nodeTexts(newState, 'list_item')).toEqual(['Nested']);
+    expect(countNodes(newState, 'bullet_list')).toBe(1);
+  });
+});
+
+// ============================================================
+//  wrapBlocksInList  —  Regression tests for Bug 3
 // ============================================================
 describe('switchListType', () => {
   it('converts a bullet list to an ordered list', () => {
@@ -551,6 +850,144 @@ describe('switchListType', () => {
       }
     });
     expect(hasChecked).toBe(true);
+  });
+
+  it('converts ordered to bullet with Milkdown-style attrs (spread)', () => {
+    // Milkdown adds a `spread` attr to both bullet_list and ordered_list.
+    // This test verifies that switchListType handles attrs correctly when the
+    // target type has fewer defined attrs than the source type.
+    const milkdownLikeSchema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { content: 'inline*', group: 'block' },
+        text: { group: 'inline' },
+        bullet_list: {
+          content: 'list_item+',
+          group: 'block',
+          attrs: { spread: { default: false } },
+        },
+        ordered_list: {
+          content: 'list_item+',
+          group: 'block',
+          attrs: { order: { default: 1 }, spread: { default: false } },
+        },
+        list_item: {
+          content: 'paragraph block*',
+          attrs: { checked: { default: null } },
+        },
+      },
+      marks: {},
+    });
+    function p(text: string) {
+      return milkdownLikeSchema.node('paragraph', null, milkdownLikeSchema.text(text));
+    }
+    function li(text: string) {
+      return milkdownLikeSchema.node('list_item', null, p(text));
+    }
+    function ol(...items: ReturnType<typeof li>[]) {
+      return milkdownLikeSchema.node('ordered_list', null, items);
+    }
+    function ul(...items: ReturnType<typeof li>[]) {
+      return milkdownLikeSchema.node('bullet_list', null, items);
+    }
+
+    const myDoc = milkdownLikeSchema.node('doc', null, ol(li('One'), li('Two')));
+    const state = EditorState.create({
+      schema: milkdownLikeSchema,
+      doc: myDoc,
+      selection: TextSelection.create(myDoc, 3),
+    });
+    const bulletList = milkdownLikeSchema.nodes.bullet_list;
+
+    const newState = applyCommand(state, (st, dispatch) =>
+      switchListType(st, bulletList, dispatch),
+    );
+
+    expect(countNodes(newState, 'bullet_list')).toBe(1);
+    expect(countNodes(newState, 'ordered_list')).toBe(0);
+    expect(nodeTexts(newState, 'list_item')).toEqual(['One', 'Two']);
+    // spread attr should be present with default value
+    let hasSpread = false;
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'bullet_list' && node.attrs.spread === false) {
+        hasSpread = true;
+      }
+    });
+    expect(hasSpread).toBe(true);
+  });
+
+  it('converts ordered to bullet with Milkdown-style list_item attrs', () => {
+    // Milkdown's list_item has label, listType, and spread attrs. When
+    // converting ordered→bullet, the list items from the ordered list
+    // have listType: 'ordered' and label: '1.' — these must be reset to
+    // defaults (listType: 'bullet', label: '•') or the editor continues
+    // rendering them as ordered items despite being inside a <ul>.
+    const fullSchema = new Schema({
+      nodes: {
+        doc: { content: 'block+' },
+        paragraph: { content: 'inline*', group: 'block' },
+        text: { group: 'inline' },
+        bullet_list: {
+          content: 'list_item+',
+          group: 'block',
+          attrs: { spread: { default: false } },
+        },
+        ordered_list: {
+          content: 'list_item+',
+          group: 'block',
+          attrs: { order: { default: 1 }, spread: { default: false } },
+        },
+        list_item: {
+          content: 'paragraph block*',
+          group: 'listItem',
+          attrs: {
+            label: { default: '•' },
+            listType: { default: 'bullet' },
+            spread: { default: true },
+          },
+        },
+      },
+      marks: {},
+    });
+    function p(text: string) {
+      return fullSchema.node('paragraph', null, fullSchema.text(text));
+    }
+    function li(text: string, attrs?: Record<string, unknown>) {
+      return fullSchema.node('list_item', attrs ?? {}, p(text));
+    }
+    function ol(...items: ReturnType<typeof li>[]) {
+      return fullSchema.node('ordered_list', null, items);
+    }
+
+    const myDoc = fullSchema.node(
+      'doc',
+      null,
+      ol(
+        li('One', { label: '1.', listType: 'ordered', spread: true }),
+        li('Two', { label: '2.', listType: 'ordered', spread: true }),
+      ),
+    );
+    const state = EditorState.create({
+      schema: fullSchema,
+      doc: myDoc,
+      selection: TextSelection.create(myDoc, 3),
+    });
+    const bulletList = fullSchema.nodes.bullet_list;
+
+    const newState = applyCommand(state, (st, dispatch) =>
+      switchListType(st, bulletList, dispatch),
+    );
+
+    expect(countNodes(newState, 'bullet_list')).toBe(1);
+    expect(countNodes(newState, 'ordered_list')).toBe(0);
+    // List items should have their attrs reset to defaults for bullet lists
+    let allBulletType = true;
+    newState.doc.descendants((node) => {
+      if (node.type.name === 'list_item' && node.attrs.listType !== 'bullet') {
+        allBulletType = false;
+      }
+    });
+    expect(allBulletType).toBe(true);
   });
 
   it('clears checked attrs when switching task list to ordered list', () => {

--- a/packages/web/src/components/editor/listCommands.ts
+++ b/packages/web/src/components/editor/listCommands.ts
@@ -50,7 +50,9 @@ export function findParentList(
   return null;
 }
 
-export function collectListItems(
+/** Collect list items at ANY depth within a position range.
+ *  Used for determining which items intersect a user's selection. */
+export function collectListItemsInRange(
   doc: Node,
   from: number,
   to: number,
@@ -62,6 +64,27 @@ export function collectListItems(
       items.push({ node, pos });
     }
   });
+  return items;
+}
+
+/** Collect only the DIRECT children of a list node.
+ *  Used by unwrapList and switchListType to operate on siblings only.
+ *  This prevents nested list items from being treated as siblings of
+ *  their parent's siblings (the root cause of nested-list duplication). */
+export function collectDirectListItems(
+  listNode: Node,
+  listStart: number,
+): Array<{ node: Node; pos: number }> {
+  const listItemType = listNode.type.schema.nodes.list_item;
+  const items: Array<{ node: Node; pos: number }> = [];
+  let childPos = listStart + 1;
+  for (let i = 0; i < listNode.content.childCount; i++) {
+    const child = listNode.content.child(i);
+    if (child.type === listItemType) {
+      items.push({ node: child, pos: childPos });
+    }
+    childPos += child.nodeSize;
+  }
   return items;
 }
 
@@ -89,11 +112,17 @@ export function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => v
   const listInfo = findParentList(state);
   if (!listInfo || !paragraphType) return false;
 
-  const allItems = collectListItems(state.doc, listInfo.start, listInfo.end);
+  // Only direct children — nested items stay encapsulated within their
+  // parent's content and are NOT unwrapped individually. This prevents
+  // the duplication bug where nested items were extracted as siblings.
+  const allItems = collectDirectListItems(listInfo.node, listInfo.start);
 
   // Determine which items to unwrap.
   // Collapsed selection: unwrap just the item under cursor.
-  // Non-empty selection: unwrap all items intersecting the range.
+  // Non-empty selection: unwrap all DIRECT items intersecting the range.
+  // We filter allItems (direct children) by overlap with the selection
+  // rather than using collectListItemsInRange (which would include
+  // nested descendants as if they were siblings).
   const { $from, $to } = state.selection;
   let unwrapPositions: Set<number>;
   let cursorItemPos = -1;
@@ -106,7 +135,11 @@ export function unwrapList(state: EditorState, dispatch?: (tr: Transaction) => v
     cursorItemPos = cursorItem.pos;
     unwrapPositions = new Set([cursorItemPos]);
   } else {
-    unwrapPositions = new Set(collectListItems(state.doc, $from.pos, $to.pos).map((i) => i.pos));
+    unwrapPositions = new Set(
+      allItems
+        .filter((item) => item.pos < $to.pos && item.pos + item.node.nodeSize > $from.pos)
+        .map((i) => i.pos),
+    );
     cursorItemPos = Math.max(...unwrapPositions);
   }
   if (unwrapPositions.size === 0) return false;
@@ -203,20 +236,33 @@ export function wrapBlocksInList(
 
   state.doc.nodesBetween(rangeFrom, rangeTo, (node, pos) => {
     if (node.isBlock && node.type !== schema.nodes.doc) {
-      const parent = state.doc.resolve(pos).parent;
+      const $pos = state.doc.resolve(pos);
+      const parent = $pos.parent;
       // Include blocks that are:
       // 1. Top-level blocks not inside any list, OR
-      // 2. Blocks inside existing lists of ANY type (to support merging
-      //    when rebuilding a numbered list after unwrap/reapply).
-      //    Skip `list_item` and `list` wrappers themselves.
+      // 2. Blocks directly inside a list_item that is itself top-level
+      //    (not nested inside another list). Nested-list blocks are
+      //    excluded because they are descendants of the parent list_item
+      //    and extracting them as separate items would break nesting.
       if (!isListItem(node) && node.type !== listType) {
         if (parent.type !== listItemType && parent.type !== listType) {
           selectedBlocks.push({ node, pos });
         } else if (parent.type === listItemType) {
-          // Inside an existing list item — use the node's actual position
-          // from nodesBetween, not an array index, so dedup and cursor
-          // calculations remain correct.
-          selectedBlocks.push({ node, pos });
+          // Only include blocks that are DIRECT children of a top-level
+          // list_item. Blocks inside nested lists (list_item's whose
+          // ancestor chain includes another list_item above depth 1)
+          // are part of the nested structure and must not be extracted.
+          let inNestedList = false;
+          const parentDepth = $pos.depth - 1;
+          for (let d = parentDepth - 1; d > 0; d--) {
+            if ($pos.node(d).type === listItemType) {
+              inNestedList = true;
+              break;
+            }
+          }
+          if (!inNestedList) {
+            selectedBlocks.push({ node, pos });
+          }
         }
       }
     }
@@ -309,6 +355,40 @@ export function wrapBlocksInList(
   return true;
 }
 
+/** Return the type of the closest (innermost) list containing the cursor.
+ *  'task' is returned when the closest list is a bullet_list whose direct
+ *  child list_item (under the cursor) has a checked attribute — indicating
+ *  a checklist/task item. Returns null when not inside any list. */
+export type ClosestListType = 'bullet' | 'ordered' | 'task' | null;
+
+export function getClosestListType(state: EditorState): ClosestListType {
+  const listInfo = findParentList(state);
+  if (!listInfo) return null;
+  if (listInfo.node.type.name === 'ordered_list') return 'ordered';
+  if (listInfo.node.type.name === 'bullet_list') {
+    const listItemType = state.schema.nodes.list_item;
+    if (!listItemType) return 'bullet';
+    const { $from } = state.selection;
+    if ($from.depth === 0) {
+      // AllSelection: scan direct children of the found list for task items.
+      // The normal ancestor-walking loop won't execute when depth is 0,
+      // so we check the list's direct children instead.
+      const items = collectDirectListItems(listInfo.node, listInfo.start);
+      if (items.some((item) => item.node.attrs.checked != null)) return 'task';
+      return 'bullet';
+    }
+    for (let d = $from.depth; d > 0; d--) {
+      const node = $from.node(d);
+      if (node.type === listItemType && node.attrs.checked != null) {
+        if ($from.node(d - 1) === listInfo.node) return 'task';
+        break;
+      }
+    }
+    return 'bullet';
+  }
+  return null;
+}
+
 /** Switch an existing list's wrapper type (e.g. bullet_list -> ordered_list). */
 export function switchListType(
   state: EditorState,
@@ -327,14 +407,23 @@ export function switchListType(
 
   const cursorOldPos = state.selection.$from.pos;
   const tr = state.tr;
-  const items = collectListItems(state.doc, listInfo.start, listInfo.end);
+  // Only direct children — switching the wrapper type should not flatten
+  // nested lists. Each item's content (including any nested sub-lists) is
+  // preserved via item.node.content.
+  const items = collectDirectListItems(listInfo.node, listInfo.start);
   const cursorItem = items.find(
     (item) => item.pos <= cursorOldPos && cursorOldPos < item.pos + item.node.nodeSize,
   );
   const cursorOffsetInItem = cursorItem ? cursorOldPos - cursorItem.pos : -1;
 
   const newItems = items.map((item) => {
-    const attrs = listItemAttrs ?? item.node.attrs;
+    // When the wrapper type changes (e.g. ordered → bullet), reset list-item
+    // attrs to schema defaults. Retaining type-specific attrs (like Milkdown's
+    // `listType: 'ordered'` or `label: '1.'`) inside a different list type
+    // causes rendering inconsistencies — the editor still treats them as the
+    // old type. When listItemAttrs is explicitly provided (task conversion),
+    // use those instead.
+    const attrs = listItemAttrs ?? (listInfo.node.type !== targetType ? {} : item.node.attrs);
     return item.node.type.create(attrs, item.node.content, item.node.marks);
   });
 

--- a/packages/web/src/contexts/KeyboardShortcutContext.tsx
+++ b/packages/web/src/contexts/KeyboardShortcutContext.tsx
@@ -78,7 +78,17 @@ export function KeyboardShortcutProvider({
       keyboardRegistry.dispatch(event, isEditableFocused());
     };
 
-    const knownBrowserShortcuts = new Set<string>(['mod+shift+8']);
+    // Zen browser emits the shifted character (event.key = '*') instead of the
+    // raw digit ('8') when Shift is held. Register both forms for each shortcut
+    // so the capture handler intercepts them regardless of browser behavior.
+    const knownBrowserShortcuts = new Set<string>([
+      'mod+shift+8',
+      'mod+shift+*',
+      'mod+shift+7',
+      'mod+shift+&',
+      'mod+shift+[',
+      'mod+shift+{',
+    ]);
 
     document.addEventListener('keydown', handler);
     window.addEventListener('keydown', captureHandler, { capture: true });


### PR DESCRIPTION
## Summary

Fixes two issues with list manipulation in the Milkdown editor:

- **Nested-list duplication**: `unwrapList` and `switchListType` were using `collectListItemsInRange` which traverses ALL descendants, causing nested list items to be treated as siblings and duplicated during unwrap/switch operations.
- **Milkdown list-item attr rendering drift**: When switching list types (e.g., ordered → bullet), type-specific attrs like `listType: 'ordered'` and `label: '1.'` were retained on list items, causing the editor to render them as the old type despite the new wrapper.

## Changes

### Core list commands (`listCommands.ts`)
- `collectDirectListItems` — new function that returns only direct children of a list node, used by `unwrapList` and `switchListType` to prevent nested-item duplication
- `blockRange` — handles AllSelection depth-0 for wrap operations
- `unwrapList` — rewritten to operate on direct children only, preserve cursor position, and maintain ordered-list numbering continuity
- `wrapBlocksInList` — wraps blocks as individual list items, normalizes headings to paragraphs, merges adjacent lists preserving `order` attr
- `switchListType` — resets list-item attrs to schema defaults when wrapper type changes (fixes Milkdown rendering drift)
- `getClosestListType` — handles `AllSelection` (Ctrl+A) depth-0 edge case for task list detection

### Editor integration (`MilkdownEditor.tsx`)
- Uses `getClosestListType` for toolbar active-state detection
- Removes unused imports

### Keyboard shortcuts (`KeyboardShortcutContext.tsx`)
- Registers dual shortcut forms for Zen browser compatibility (e.g., `mod+shift+8` and `mod+shift+*`)

## Related Issues

Closes #75
Closes #76