### PR TITLE
fix(deploy): persist uploaded images across container restarts

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -27,6 +27,7 @@ pnpm --filter @markdawn/collab build
 
 echo -e "${YELLOW}[STEP 4/6] Updating Podman Quadlet units...${NC}"
 podman volume create postgres-data 2>/dev/null || true
+podman volume create markdawn-data 2>/dev/null || true
 cp "$REPO_DIR/deploy/quadlet/markdawn.pod" ~/.config/containers/systemd/
 cp "$REPO_DIR/deploy/quadlet/markdawn-postgres.container" ~/.config/containers/systemd/
 cp "$REPO_DIR/deploy/quadlet/markdawn-api.container" ~/.config/containers/systemd/

--- a/deploy/quadlet/markdawn-api.container
+++ b/deploy/quadlet/markdawn-api.container
@@ -12,7 +12,7 @@ Environment=PORT=3001
 EnvironmentFile=/var/www/markdawn/.env
 WorkingDir=/app
 Exec=node /app/packages/api/dist/index.mjs
-Volume=markdawn-data.volume:/app/packages/api/uploads:Z
+Volume=markdawn-data:/app/packages/api/uploads:Z
 
 
 [Service]

--- a/deploy/quadlet/markdawn-api.container
+++ b/deploy/quadlet/markdawn-api.container
@@ -12,6 +12,7 @@ Environment=PORT=3001
 EnvironmentFile=/var/www/markdawn/.env
 WorkingDir=/app
 Exec=node /app/packages/api/dist/index.mjs
+Volume=markdawn-data.volume:/app/packages/api/uploads:Z
 
 
 [Service]

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -70,6 +70,7 @@ echo -e "${YELLOW}[STEP 7/8] Setting up Podman Quadlet services...${NC}"
 mkdir -p ~/.config/containers/systemd
 
 podman volume create postgres-data 2>/dev/null || true
+podman volume create markdawn-data 2>/dev/null || true
 
 cp "$REPO_DIR/deploy/quadlet/markdawn.pod" ~/.config/containers/systemd/
 cp "$REPO_DIR/deploy/quadlet/markdawn-postgres.container" ~/.config/containers/systemd/

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -113,7 +113,7 @@ sudo systemctl reload caddy
 This script will:
 1. Install Podman and common tools
 2. Enable lingering for user systemd services
-3. Create a persistent Podman volume for PostgreSQL
+3. Create persistent Podman volumes for PostgreSQL and uploads
 4. Copy Quadlet files to `~/.config/containers/systemd/`
 5. Build container images
 6. Start PostgreSQL and wait for it to be healthy


### PR DESCRIPTION
Uploaded images were stored in the container's ephemeral filesystem at `/app/packages/api/uploads/` and lost every time the Podman container restarted. The database records survived, so the GET route would find the DB row but return 404 when the disk file was gone.

**Fix:** Mount the existing (but unused) `markdawn-data` Podman volume to `/app/packages/api/uploads` with SELinux `:Z` labeling, matching the pattern already used by the PostgreSQL container.

**Changes:**
- `deploy/quadlet/markdawn-api.container` — added `Volume=markdawn-data.volume:/app/packages/api/uploads:Z`
- `deploy/setup.sh` — creates `markdawn-data` volume on initial setup
- `deploy/deploy.sh` — creates `markdawn-data` volume on incremental deploys
- `docs/deployment_guide.md` — updated step to mention uploads volume

Closes #84