### PR TITLE
fix(web): add color-scheme and WebKit scrollbar styles for dark mode

### DIFF
--- a/e2e/page-features/dark-mode.spec.ts
+++ b/e2e/page-features/dark-mode.spec.ts
@@ -10,6 +10,7 @@ test.describe('Dark mode', () => {
     await page.waitForURL(/\/app\//);
 
     await expect(page.locator('html')).toHaveClass(/dark/, { timeout: 10000 });
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
   });
 
   test('light mode removes dark class from html', async ({ page }) => {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -8,11 +8,13 @@
           if (isDark) {
             document.documentElement.classList.add('dark');
             document.documentElement.style.backgroundColor = '#09090b';
+            document.documentElement.style.colorScheme = 'dark';
             if (document.body) {
               document.body.style.backgroundColor = '#09090b';
             }
           } else {
             document.documentElement.style.backgroundColor = '#ffffff';
+            document.documentElement.style.colorScheme = 'light';
             if (document.body) {
               document.body.style.backgroundColor = '#ffffff';
             }

--- a/packages/web/src/components/editor/Breadcrumbs.tsx
+++ b/packages/web/src/components/editor/Breadcrumbs.tsx
@@ -75,7 +75,7 @@ export function Breadcrumbs({
   }
 
   return (
-    <div className="flex items-center gap-1 text-sm font-medium text-zinc-500 dark:text-zinc-400 overflow-x-auto whitespace-nowrap scrollbar-hide">
+    <div className="flex items-center gap-1 text-sm font-medium text-zinc-500 dark:text-zinc-400 overflow-x-auto whitespace-nowrap scrollbar-none">
       <Link
         to={`/app/${workspaceSlug}`}
         className="hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors px-1.5 py-0.5 -ml-1.5 rounded-md hover:bg-zinc-100 dark:hover:bg-zinc-800/50"

--- a/packages/web/src/hooks/useTheme.ts
+++ b/packages/web/src/hooks/useTheme.ts
@@ -24,8 +24,10 @@ function applyTheme(theme: Theme) {
   const dark = readIsDark(theme);
   if (dark) {
     root.classList.add('dark');
+    root.style.colorScheme = 'dark';
   } else {
     root.classList.remove('dark');
+    root.style.colorScheme = 'light';
   }
   localStorage.setItem(THEME_KEY, theme);
 }

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -11,6 +11,7 @@
 }
 
 :root {
+  color-scheme: light;
   --color-surface: #fafafa;
   --color-surface-alt: #f4f4f5;
   --color-surface-elevated: #e4e4e7;
@@ -20,12 +21,38 @@
 }
 
 .dark {
+  color-scheme: dark;
   --color-surface: #09090b;
   --color-surface-alt: #18181b;
   --color-surface-elevated: #27272a;
   --color-border: #3f3f46;
   --color-text: #fafafa;
   --color-text-muted: #a1a1aa;
+}
+
+/* Chrome, Safari, Edge: thin pill-shaped scrollbar */
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--color-zinc-300);
+  border-radius: 3px;
+  transition: background 150ms ease;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--color-zinc-400);
+}
+.dark *::-webkit-scrollbar-thumb,
+.dark::-webkit-scrollbar-thumb {
+  background: var(--color-zinc-600);
+}
+.dark *::-webkit-scrollbar-thumb:hover,
+.dark::-webkit-scrollbar-thumb:hover {
+  background: var(--color-zinc-500);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Fixes Chrome scrollbar rendering in dark mode — native scrollbars were showing light colors because Chrome wasn't told the page was dark. Also fixes a dead Tailwind class on Breadcrumbs.

## Changes

- **`packages/web/src/index.css`**: Added `color-scheme: light` on `:root` and `color-scheme: dark` on `.dark` so Chrome renders native scrollbar in the correct color. Added custom 6px WebKit scrollbar with zinc-300/600 pill-shaped thumb and hover states.
- **`packages/web/index.html`**: Set `colorScheme` inline style in FOUC script to prevent flash of wrong scrollbar color before CSS loads.
- **`packages/web/src/hooks/useTheme.ts`**: Fixed `applyTheme()` to sync the inline `colorScheme` on theme toggle, preventing the FOUC inline style from persisting beyond runtime toggles.
- **`packages/web/src/components/editor/Breadcrumbs.tsx`**: Replaced dead `scrollbar-hide` class with `scrollbar-none` (Tailwind v4 utility).
- **`e2e/page-features/dark-mode.spec.ts`**: Added assertion verifying `color-scheme: dark` is applied in dark mode.

Closes #79