### PR TITLE
fix(web): navigate to home when deleting the currently open page

### DIFF
--- a/packages/web/src/components/sidebar/PageTree.tsx
+++ b/packages/web/src/components/sidebar/PageTree.tsx
@@ -17,6 +17,7 @@ import {
   useUpdatePage,
 } from '../../hooks/use-pages';
 import { showErrorToast, showSuccessToast } from '../../utils/toast';
+import { extractUuidFromSlug } from '../../utils/url';
 import { ConfirmDialog } from '../ConfirmDialog';
 import { PageTreeRow } from './PageTreeRow';
 
@@ -33,7 +34,7 @@ type EditingTarget =
 export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   const navigate = useNavigate();
   const params = useParams();
-  const activePageId = params.pageId;
+  const activePageId = params.slugAndId ? extractUuidFromSlug(params.slugAndId) : undefined;
 
   const { data: pages, isLoading: isPagesLoading, error: pagesError } = usePageTree(workspaceId);
   const {

--- a/packages/web/src/routes/Page.tsx
+++ b/packages/web/src/routes/Page.tsx
@@ -16,6 +16,7 @@ import { TableOfContents } from '../components/editor/TableOfContents';
 import { useFolderTree } from '../hooks/use-folders';
 import { usePageTree } from '../hooks/use-pages';
 import { useWorkspaces } from '../hooks/use-workspaces';
+import { extractUuidFromSlug } from '../utils/url';
 
 const API_BASE = '/api';
 
@@ -34,14 +35,6 @@ function decodePageContent(ydoc: unknown): string {
     return new TextDecoder().decode(new Uint8Array(ydoc as number[]));
   }
   return '';
-}
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function extractUuidFromSlug(slug: string): string | undefined {
-  const uuidMatch = slug.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
-  const candidate = uuidMatch?.[1];
-  return candidate && UUID_REGEX.test(candidate) ? candidate : undefined;
 }
 
 function slugifyTitle(title: string): string {

--- a/packages/web/src/utils/url.test.ts
+++ b/packages/web/src/utils/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ensureAbsoluteUrl } from './url';
+import { ensureAbsoluteUrl, extractUuidFromSlug } from './url';
 
 describe('ensureAbsoluteUrl', () => {
   // Bare domains
@@ -94,5 +94,33 @@ describe('ensureAbsoluteUrl', () => {
 
   it('trims whitespace before checking', () => {
     expect(ensureAbsoluteUrl('  samvaad.live  ')).toBe('https://samvaad.live');
+  });
+});
+
+describe('extractUuidFromSlug', () => {
+  const uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('extracts uuid from slug-title-uuid format', () => {
+    expect(extractUuidFromSlug(`my-page-title-${uuid}`)).toBe(uuid);
+  });
+
+  it('extracts uuid from bare uuid', () => {
+    expect(extractUuidFromSlug(uuid)).toBe(uuid);
+  });
+
+  it('extracts uuid when slug has multiple hyphens', () => {
+    expect(extractUuidFromSlug(`a-page-with-many-hyphens-${uuid}`)).toBe(uuid);
+  });
+
+  it('returns undefined when no uuid present', () => {
+    expect(extractUuidFromSlug('just-a-regular-slug')).toBeUndefined();
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(extractUuidFromSlug('')).toBeUndefined();
+  });
+
+  it('returns undefined for malformed uuid', () => {
+    expect(extractUuidFromSlug('page-550e8400-invalid')).toBeUndefined();
   });
 });

--- a/packages/web/src/utils/url.ts
+++ b/packages/web/src/utils/url.ts
@@ -1,3 +1,11 @@
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function extractUuidFromSlug(slug: string): string | undefined {
+  const uuidMatch = slug.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+  const candidate = uuidMatch?.[1];
+  return candidate && UUID_REGEX.test(candidate) ? candidate : undefined;
+}
+
 export function ensureAbsoluteUrl(url: string): string {
   if (!url) return url;
 


### PR DESCRIPTION
## Summary

When a page is open in the editor and deleted from the sidebar, the app now navigates to the workspace home instead of leaving the user on a stale/deleted page view.

## Root cause

The route parameter was renamed from `:pageId` to `:slugAndId` in `dae891e` (to support SEO-friendly title slugs), but `PageTree.tsx` was never updated — it still read `params.pageId`, which was always `undefined`. The navigation guard in `handleDeletePage` (`if (activePageId === pageId)`) never fired.

## Changes

1. **refactor(web):** Extract `extractUuidFromSlug` from `Page.tsx` into `packages/web/src/utils/url.ts` so both `Page` and `PageTree` can use it.

2. **fix(web):** Read `params.slugAndId` in `PageTree` and extract the UUID instead of the stale `params.pageId`.

3. **test(web):** 6 test cases covering slug-title-uuid, bare UUID, hyphenated slugs, empty input, missing UUID, and malformed UUID.

Closes #82