### PR TITLE
fix(web): reorder sidebar and split home view into favorites and all-pages sections

### DIFF
--- a/packages/web/src/components/sidebar/PageTree.tsx
+++ b/packages/web/src/components/sidebar/PageTree.tsx
@@ -53,6 +53,11 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   } = useFolderTree(workspaceId);
   const { data: favorites } = useFavorites(workspaceId);
 
+  const favoritePageIds = useMemo(
+    () => new Set(favorites?.map((fav) => fav.pageId) ?? []),
+    [favorites],
+  );
+
   const createPageMutation = useCreatePage();
   const updatePageMutation = useUpdatePage();
   const deletePageMutation = useDeletePage();
@@ -277,15 +282,11 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   };
 
   const handleToggleFavorite = async (pageId: string, isCurrentlyFavorite: boolean) => {
-    try {
-      await toggleFavoriteMutation.mutateAsync({
-        pageId,
-        isFavorite: isCurrentlyFavorite,
-        workspaceId,
-      });
-    } catch {
-      showErrorToast(isCurrentlyFavorite ? 'Failed to remove favorite' : 'Failed to add favorite');
-    }
+    await toggleFavoriteMutation.mutateAsync({
+      pageId,
+      isFavorite: isCurrentlyFavorite,
+      workspaceId,
+    });
   };
 
   const handleExport = async (pageId: string, title: string) => {
@@ -404,12 +405,9 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
                   workspaceSlug={workspaceSlug}
                   depth={depth + 1}
                   isActive={activePageId === page.id}
-                  isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
+                  isFavorite={favoritePageIds.has(page.id)}
                   onToggleFavorite={() =>
-                    handleToggleFavorite(
-                      page.id,
-                      favorites?.some((fav) => fav.pageId === page.id) ?? false,
-                    )
+                    handleToggleFavorite(page.id, favoritePageIds.has(page.id))
                   }
                   onDelete={() => handleDeletePage(page.id)}
                   onRename={() => beginRenamePage(page)}
@@ -514,6 +512,7 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
             <button
               type="button"
               onClick={() => setFavoritesCollapsed((prev) => !prev)}
+              aria-expanded={!favoritesCollapsed}
               className="flex items-center px-4 mb-2 text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors w-full text-left"
             >
               {favoritesCollapsed ? (
@@ -548,6 +547,7 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
           <button
             type="button"
             onClick={() => setAllPagesCollapsed((prev) => !prev)}
+            aria-expanded={!allPagesCollapsed}
             className="flex items-center px-4 mb-2 text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors w-full text-left"
           >
             {allPagesCollapsed ? (
@@ -571,12 +571,9 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
                     icon={page.icon}
                     workspaceSlug={workspaceSlug}
                     isActive={activePageId === page.id}
-                    isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
+                    isFavorite={favoritePageIds.has(page.id)}
                     onToggleFavorite={() =>
-                      handleToggleFavorite(
-                        page.id,
-                        favorites?.some((fav) => fav.pageId === page.id) ?? false,
-                      )
+                      handleToggleFavorite(page.id, favoritePageIds.has(page.id))
                     }
                     onDelete={() => handleDeletePage(page.id)}
                     onRename={() => beginRenamePage(page)}
@@ -602,12 +599,9 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
                     icon={page.icon}
                     workspaceSlug={workspaceSlug}
                     isActive={activePageId === page.id}
-                    isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
+                    isFavorite={favoritePageIds.has(page.id)}
                     onToggleFavorite={() =>
-                      handleToggleFavorite(
-                        page.id,
-                        favorites?.some((fav) => fav.pageId === page.id) ?? false,
-                      )
+                      handleToggleFavorite(page.id, favoritePageIds.has(page.id))
                     }
                     onDelete={() => handleDeletePage(page.id)}
                     onRename={() => beginRenamePage(page)}

--- a/packages/web/src/components/sidebar/PageTree.tsx
+++ b/packages/web/src/components/sidebar/PageTree.tsx
@@ -1,5 +1,14 @@
 import type { FolderTreeNode, PageTreeNode } from '@markdawn/shared';
-import { ChevronsDown, ChevronsUp, Download, FilePlus2, FolderPlus, Home } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronRight,
+  ChevronsDown,
+  ChevronsUp,
+  Download,
+  FilePlus2,
+  FolderPlus,
+  Home,
+} from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useFavorites, useToggleFavorite } from '../../hooks/use-favorites';
@@ -54,6 +63,8 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   const importMarkdownMutation = useImportMarkdown();
 
   const [expandedFolderIds, setExpandedFolderIds] = useState<Set<string>>(new Set());
+  const [favoritesCollapsed, setFavoritesCollapsed] = useState(false);
+  const [allPagesCollapsed, setAllPagesCollapsed] = useState(false);
   const [editingTarget, setEditingTarget] = useState<EditingTarget>(null);
   const [hasInitializedExpansion, setHasInitializedExpansion] = useState(false);
   const [deleteFolderConfirm, setDeleteFolderConfirm] = useState<{
@@ -182,8 +193,12 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   const toggleExpandAll = () => {
     if (isAllExpanded) {
       setExpandedFolderIds(new Set());
+      setFavoritesCollapsed(true);
+      setAllPagesCollapsed(true);
     } else {
       setExpandedFolderIds(new Set(allFolderIds));
+      setFavoritesCollapsed(false);
+      setAllPagesCollapsed(false);
     }
   };
 
@@ -261,11 +276,15 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
     }
   };
 
-  const handleUnfavorite = async (pageId: string) => {
+  const handleToggleFavorite = async (pageId: string, isCurrentlyFavorite: boolean) => {
     try {
-      await toggleFavoriteMutation.mutateAsync({ pageId, isFavorite: true, workspaceId });
+      await toggleFavoriteMutation.mutateAsync({
+        pageId,
+        isFavorite: isCurrentlyFavorite,
+        workspaceId,
+      });
     } catch {
-      showErrorToast('Failed to remove favorite');
+      showErrorToast(isCurrentlyFavorite ? 'Failed to remove favorite' : 'Failed to add favorite');
     }
   };
 
@@ -386,7 +405,12 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
                   depth={depth + 1}
                   isActive={activePageId === page.id}
                   isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
-                  onToggleFavorite={() => handleUnfavorite(page.id)}
+                  onToggleFavorite={() =>
+                    handleToggleFavorite(
+                      page.id,
+                      favorites?.some((fav) => fav.pageId === page.id) ?? false,
+                    )
+                  }
                   onDelete={() => handleDeletePage(page.id)}
                   onRename={() => beginRenamePage(page)}
                   onExport={() => handleExport(page.id, page.title)}
@@ -433,139 +457,178 @@ export function PageTree({ workspaceId, workspaceSlug }: PageTreeProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto px-2 py-2 space-y-3">
+        <div className="flex items-center justify-center gap-1 mb-2">
+          <button
+            type="button"
+            onClick={() => {
+              navigate(`/app/${workspaceSlug}`);
+            }}
+            className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
+            title="Go to workspace home"
+            data-testid="home-btn"
+          >
+            <Home size={16} />
+          </button>
+          <label
+            className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
+            title="Import markdown file"
+          >
+            <input type="file" accept=".md" className="hidden" onChange={handleImportMarkdown} />
+            <Download size={16} />
+          </label>
+          <button
+            type="button"
+            onClick={() => {
+              void handleCreateRootFolder();
+            }}
+            className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
+            title="Create folder (Ctrl/Cmd+Shift+N)"
+            data-testid="new-folder-btn"
+          >
+            <FolderPlus size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void handleCreateRootPage();
+            }}
+            className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
+            title="Create note (Ctrl/Cmd+N)"
+            data-testid="new-page-btn"
+          >
+            <FilePlus2 size={16} />
+          </button>
+          <button
+            type="button"
+            onClick={toggleExpandAll}
+            className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
+            title={isAllExpanded ? 'Collapse all folders' : 'Expand all folders'}
+            data-testid="toggle-expand-all-btn"
+          >
+            {isAllExpanded ? <ChevronsUp size={16} /> : <ChevronsDown size={16} />}
+          </button>
+        </div>
+
         {favorites && favorites.length > 0 && (
           <div className="mb-2">
-            <div className="flex items-center px-4 mb-2 text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider">
+            <button
+              type="button"
+              onClick={() => setFavoritesCollapsed((prev) => !prev)}
+              className="flex items-center px-4 mb-2 text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors w-full text-left"
+            >
+              {favoritesCollapsed ? (
+                <ChevronRight size={14} className="mr-1 shrink-0" />
+              ) : (
+                <ChevronDown size={14} className="mr-1 shrink-0" />
+              )}
               <span>Favorites</span>
-            </div>
-            <div className="space-y-0.5">
-              {favorites.map((fav) => (
-                <PageTreeRow
-                  key={fav.pageId}
-                  id={fav.pageId}
-                  title={fav.title}
-                  icon={fav.icon}
-                  workspaceSlug={workspaceSlug}
-                  isActive={activePageId === fav.pageId}
-                  isFavorite={true}
-                  onToggleFavorite={() => handleUnfavorite(fav.pageId)}
-                  onDelete={() => handleDeletePage(fav.pageId)}
-                  onExport={() => handleExport(fav.pageId, fav.title)}
-                />
-              ))}
-            </div>
+            </button>
+            {!favoritesCollapsed && (
+              <div className="space-y-0.5">
+                {favorites.map((fav) => (
+                  <PageTreeRow
+                    key={fav.pageId}
+                    id={fav.pageId}
+                    title={fav.title}
+                    icon={fav.icon}
+                    workspaceSlug={workspaceSlug}
+                    isActive={activePageId === fav.pageId}
+                    isFavorite={true}
+                    onToggleFavorite={() => handleToggleFavorite(fav.pageId, true)}
+                    onDelete={() => handleDeletePage(fav.pageId)}
+                    onExport={() => handleExport(fav.pageId, fav.title)}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         )}
 
         <div>
-          <div className="flex items-center justify-center gap-1 mb-2">
-            <button
-              type="button"
-              onClick={() => {
-                navigate(`/app/${workspaceSlug}`);
-              }}
-              className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
-              title="Go to workspace home"
-              data-testid="home-btn"
-            >
-              <Home size={16} />
-            </button>
-            <label
-              className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
-              title="Import markdown file"
-            >
-              <input type="file" accept=".md" className="hidden" onChange={handleImportMarkdown} />
-              <Download size={16} />
-            </label>
-            <button
-              type="button"
-              onClick={() => {
-                void handleCreateRootFolder();
-              }}
-              className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
-              title="Create folder (Ctrl/Cmd+Shift+N)"
-              data-testid="new-folder-btn"
-            >
-              <FolderPlus size={16} />
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                void handleCreateRootPage();
-              }}
-              className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
-              title="Create note (Ctrl/Cmd+N)"
-              data-testid="new-page-btn"
-            >
-              <FilePlus2 size={16} />
-            </button>
-            <button
-              type="button"
-              onClick={toggleExpandAll}
-              className="p-1.5 hover:bg-black/5 dark:hover:bg-white/10 rounded-lg transition-all text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 cursor-pointer"
-              title={isAllExpanded ? 'Collapse all folders' : 'Expand all folders'}
-              data-testid="toggle-expand-all-btn"
-            >
-              {isAllExpanded ? <ChevronsUp size={16} /> : <ChevronsDown size={16} />}
-            </button>
-          </div>
-
-          <div className="space-y-0.5">
-            {rootFolders.map((folder) => renderFolderBranch(folder, 0))}
-            {rootPages.map((page) => {
-              const isEditingPage = editingTarget?.kind === 'page' && editingTarget.id === page.id;
-              return (
-                <PageTreeRow
-                  key={page.id}
-                  id={page.id}
-                  title={page.title}
-                  icon={page.icon}
-                  workspaceSlug={workspaceSlug}
-                  isActive={activePageId === page.id}
-                  isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
-                  onToggleFavorite={() => handleUnfavorite(page.id)}
-                  onDelete={() => handleDeletePage(page.id)}
-                  onRename={() => beginRenamePage(page)}
-                  onExport={() => handleExport(page.id, page.title)}
-                  isEditing={isEditingPage}
-                  editTitle={isEditingPage ? editingTarget.value : page.title}
-                  onEditChange={(value) => setEditingTarget({ kind: 'page', id: page.id, value })}
-                  onEditSave={() => {
-                    void saveRename();
-                  }}
-                  onEditKeyDown={onRenameKeyDown}
-                />
-              );
-            })}
-            {orphanNestedPages.map((page) => {
-              const isEditingPage = editingTarget?.kind === 'page' && editingTarget.id === page.id;
-              return (
-                <PageTreeRow
-                  key={`orphan-${page.id}`}
-                  id={page.id}
-                  title={page.title}
-                  icon={page.icon}
-                  workspaceSlug={workspaceSlug}
-                  isActive={activePageId === page.id}
-                  isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
-                  onToggleFavorite={() => handleUnfavorite(page.id)}
-                  onDelete={() => handleDeletePage(page.id)}
-                  onRename={() => beginRenamePage(page)}
-                  onExport={() => handleExport(page.id, page.title)}
-                  isEditing={isEditingPage}
-                  editTitle={isEditingPage ? editingTarget.value : page.title}
-                  onEditChange={(value) => setEditingTarget({ kind: 'page', id: page.id, value })}
-                  onEditSave={() => {
-                    void saveRename();
-                  }}
-                  onEditKeyDown={onRenameKeyDown}
-                />
-              );
-            })}
-            {rootFolders.length === 0 && rootPages.length === 0 && (
-              <div className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">No notes yet</div>
+          <button
+            type="button"
+            onClick={() => setAllPagesCollapsed((prev) => !prev)}
+            className="flex items-center px-4 mb-2 text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors w-full text-left"
+          >
+            {allPagesCollapsed ? (
+              <ChevronRight size={14} className="mr-1 shrink-0" />
+            ) : (
+              <ChevronDown size={14} className="mr-1 shrink-0" />
             )}
-          </div>
+            <span>All Pages</span>
+          </button>
+          {!allPagesCollapsed && (
+            <div className="space-y-0.5">
+              {rootFolders.map((folder) => renderFolderBranch(folder, 0))}
+              {rootPages.map((page) => {
+                const isEditingPage =
+                  editingTarget?.kind === 'page' && editingTarget.id === page.id;
+                return (
+                  <PageTreeRow
+                    key={page.id}
+                    id={page.id}
+                    title={page.title}
+                    icon={page.icon}
+                    workspaceSlug={workspaceSlug}
+                    isActive={activePageId === page.id}
+                    isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
+                    onToggleFavorite={() =>
+                      handleToggleFavorite(
+                        page.id,
+                        favorites?.some((fav) => fav.pageId === page.id) ?? false,
+                      )
+                    }
+                    onDelete={() => handleDeletePage(page.id)}
+                    onRename={() => beginRenamePage(page)}
+                    onExport={() => handleExport(page.id, page.title)}
+                    isEditing={isEditingPage}
+                    editTitle={isEditingPage ? editingTarget.value : page.title}
+                    onEditChange={(value) => setEditingTarget({ kind: 'page', id: page.id, value })}
+                    onEditSave={() => {
+                      void saveRename();
+                    }}
+                    onEditKeyDown={onRenameKeyDown}
+                  />
+                );
+              })}
+              {orphanNestedPages.map((page) => {
+                const isEditingPage =
+                  editingTarget?.kind === 'page' && editingTarget.id === page.id;
+                return (
+                  <PageTreeRow
+                    key={`orphan-${page.id}`}
+                    id={page.id}
+                    title={page.title}
+                    icon={page.icon}
+                    workspaceSlug={workspaceSlug}
+                    isActive={activePageId === page.id}
+                    isFavorite={favorites?.some((fav) => fav.pageId === page.id) ?? false}
+                    onToggleFavorite={() =>
+                      handleToggleFavorite(
+                        page.id,
+                        favorites?.some((fav) => fav.pageId === page.id) ?? false,
+                      )
+                    }
+                    onDelete={() => handleDeletePage(page.id)}
+                    onRename={() => beginRenamePage(page)}
+                    onExport={() => handleExport(page.id, page.title)}
+                    isEditing={isEditingPage}
+                    editTitle={isEditingPage ? editingTarget.value : page.title}
+                    onEditChange={(value) => setEditingTarget({ kind: 'page', id: page.id, value })}
+                    onEditSave={() => {
+                      void saveRename();
+                    }}
+                    onEditKeyDown={onRenameKeyDown}
+                  />
+                );
+              })}
+              {rootFolders.length === 0 && rootPages.length === 0 && (
+                <div className="px-3 py-2 text-sm text-zinc-500 dark:text-zinc-400">
+                  No notes yet
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 

--- a/packages/web/src/components/workspace/ExplorerItem.tsx
+++ b/packages/web/src/components/workspace/ExplorerItem.tsx
@@ -139,6 +139,24 @@ export function ExplorerItem({
     onSelect(e);
   };
 
+  const renderFavoriteToggle = () => {
+    if (item.type !== 'page' || !onToggleFavorite) return null;
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowMenu(false);
+          onToggleFavorite();
+        }}
+        className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
+      >
+        <Star size={14} className={isFavorite ? 'text-yellow-500' : ''} />
+        {isFavorite ? 'Unfavorite' : 'Favorite'}
+      </button>
+    );
+  };
+
   const updatedDate =
     typeof item.updatedAt === 'string' ? item.updatedAt : item.updatedAt.toISOString();
 
@@ -242,20 +260,7 @@ export function ExplorerItem({
                       <FileText size={14} /> Open
                     </button>
                   )}
-                  {item.type === 'page' && onToggleFavorite && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setShowMenu(false);
-                        onToggleFavorite();
-                      }}
-                      className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
-                    >
-                      <Star size={14} className={isFavorite ? 'text-yellow-500' : ''} />
-                      {isFavorite ? 'Unfavorite' : 'Favorite'}
-                    </button>
-                  )}
+                  {renderFavoriteToggle()}
                   <button
                     type="button"
                     onClick={(e) => {
@@ -461,20 +466,7 @@ export function ExplorerItem({
                       <FileText size={14} /> Open
                     </button>
                   )}
-                  {item.type === 'page' && onToggleFavorite && (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setShowMenu(false);
-                        onToggleFavorite();
-                      }}
-                      className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
-                    >
-                      <Star size={14} className={isFavorite ? 'text-yellow-500' : ''} />
-                      {isFavorite ? 'Unfavorite' : 'Favorite'}
-                    </button>
-                  )}
+                  {renderFavoriteToggle()}
                   <button
                     type="button"
                     onClick={(e) => {

--- a/packages/web/src/components/workspace/ExplorerItem.tsx
+++ b/packages/web/src/components/workspace/ExplorerItem.tsx
@@ -9,6 +9,7 @@ import {
   FolderInput,
   MoreHorizontal,
   Scissors,
+  Star,
   Trash2,
 } from 'lucide-react';
 import type React from 'react';
@@ -33,6 +34,8 @@ interface ExplorerItemProps {
   item: ExplorerItemData;
   viewMode: 'card' | 'list';
   isSelected: boolean;
+  isFavorite?: boolean;
+  onToggleFavorite?: () => void;
   workspaceSlug: string;
   onSelect: (e: React.MouseEvent) => void;
   onNavigate: (e: React.MouseEvent) => void;
@@ -53,6 +56,8 @@ export function ExplorerItem({
   item,
   viewMode,
   isSelected,
+  isFavorite = false,
+  onToggleFavorite,
   workspaceSlug,
   onSelect,
   onNavigate,
@@ -235,6 +240,20 @@ export function ExplorerItem({
                       className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
                     >
                       <FileText size={14} /> Open
+                    </button>
+                  )}
+                  {item.type === 'page' && onToggleFavorite && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onToggleFavorite();
+                      }}
+                      className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
+                    >
+                      <Star size={14} className={isFavorite ? 'text-yellow-500' : ''} />
+                      {isFavorite ? 'Unfavorite' : 'Favorite'}
                     </button>
                   )}
                   <button
@@ -440,6 +459,20 @@ export function ExplorerItem({
                       className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
                     >
                       <FileText size={14} /> Open
+                    </button>
+                  )}
+                  {item.type === 'page' && onToggleFavorite && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowMenu(false);
+                        onToggleFavorite();
+                      }}
+                      className="flex items-center gap-2.5 px-2.5 py-2 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:bg-black/5 dark:hover:bg-white/10 w-full text-left cursor-pointer rounded-xl transition-colors"
+                    >
+                      <Star size={14} className={isFavorite ? 'text-yellow-500' : ''} />
+                      {isFavorite ? 'Unfavorite' : 'Favorite'}
                     </button>
                   )}
                   <button

--- a/packages/web/src/routes/Workspace.tsx
+++ b/packages/web/src/routes/Workspace.tsx
@@ -23,6 +23,7 @@ import {
   useBulkMovePages,
 } from '../hooks/use-bulk-actions';
 import { useCopyFolder, useCopyPage } from '../hooks/use-copy';
+import { useFavorites, useToggleFavorite } from '../hooks/use-favorites';
 import {
   useCreateFolder,
   useDeleteFolder,
@@ -48,6 +49,13 @@ export default function Workspace() {
     isLoading: isFoldersLoading,
     error: foldersError,
   } = useFolderTree(workspace?.id ?? '');
+  const { data: favorites } = useFavorites(workspace?.id);
+  const toggleFavoriteMutation = useToggleFavorite();
+
+  const favoritePageIds = useMemo(
+    () => new Set(favorites?.map((fav) => fav.pageId) ?? []),
+    [favorites],
+  );
 
   const createPageMutation = useCreatePage();
   const createFolderMutation = useCreateFolder();
@@ -159,6 +167,11 @@ export default function Workspace() {
     return [...folderItems, ...pageItems];
   }, [currentFolders, currentPages]);
 
+  const favoriteItems = useMemo(
+    () => allItems.filter((item) => item.type === 'page' && favoritePageIds.has(item.id)),
+    [allItems, favoritePageIds],
+  );
+
   const handleCreatePage = async () => {
     if (!workspace?.id) return;
     try {
@@ -268,6 +281,20 @@ export default function Workspace() {
       showSuccessToast('Exported to markdown');
     } catch {
       showErrorToast('Failed to export');
+    }
+  };
+
+  const handleToggleFavorite = async (pageId: string) => {
+    if (!workspace?.id) return;
+    const isCurrentlyFavorite = favoritePageIds.has(pageId);
+    try {
+      await toggleFavoriteMutation.mutateAsync({
+        pageId,
+        isFavorite: isCurrentlyFavorite,
+        workspaceId: workspace.id,
+      });
+    } catch {
+      showErrorToast(isCurrentlyFavorite ? 'Failed to remove favorite' : 'Failed to add favorite');
     }
   };
 
@@ -529,76 +556,190 @@ export default function Workspace() {
           </p>
         </div>
       ) : viewMode === 'card' ? (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 animate-fade-in">
-          {allItems.map((item, index) => (
-            <ExplorerItem
-              key={`${item.type}-${item.id}`}
-              item={item}
-              viewMode="card"
-              isSelected={selection.isSelected(item.id)}
-              workspaceSlug={workspaceSlug ?? ''}
-              onSelect={(e) => {
-                e.stopPropagation();
-                selection.toggle({ id: item.id, type: item.type });
-              }}
-              onNavigate={(e) => handleItemClick(item, index, e)}
-              onDelete={() => void handleDeleteItem(item)}
-              onRename={() => handleRenameItem(item)}
-              onCopy={() => handleCopyItem(item)}
-              onCut={() => handleCutItem(item)}
-              onMove={() => handleMoveItem(item)}
-              {...(item.type === 'page'
-                ? { onExport: () => void handleExport(item.id, item.title) }
-                : {})}
-              isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
-              editValue={editingTarget?.value ?? ''}
-              onEditChange={(value) =>
-                setEditingTarget((prev) => (prev ? { ...prev, value } : null))
-              }
-              onEditSave={() => void handleSaveRename()}
-              onEditKeyDown={handleEditKeyDown}
-            />
-          ))}
+        <div className="space-y-8 animate-fade-in">
+          {favoriteItems.length > 0 && (
+            <div>
+              <h2 className="text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-3 px-1">
+                Favorites
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {favoriteItems.map((item, index) => (
+                  <ExplorerItem
+                    key={`${item.type}-${item.id}`}
+                    item={item}
+                    viewMode="card"
+                    isSelected={selection.isSelected(item.id)}
+                    workspaceSlug={workspaceSlug ?? ''}
+                    isFavorite={favoritePageIds.has(item.id)}
+                    onToggleFavorite={() => {
+                      void handleToggleFavorite(item.id);
+                    }}
+                    onSelect={(e) => {
+                      e.stopPropagation();
+                      selection.toggle({ id: item.id, type: item.type });
+                    }}
+                    onNavigate={(e) => handleItemClick(item, index, e)}
+                    onDelete={() => void handleDeleteItem(item)}
+                    onRename={() => handleRenameItem(item)}
+                    onCopy={() => handleCopyItem(item)}
+                    onCut={() => handleCutItem(item)}
+                    onMove={() => handleMoveItem(item)}
+                    {...(item.type === 'page'
+                      ? { onExport: () => void handleExport(item.id, item.title) }
+                      : {})}
+                    isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
+                    editValue={editingTarget?.value ?? ''}
+                    onEditChange={(value) =>
+                      setEditingTarget((prev) => (prev ? { ...prev, value } : null))
+                    }
+                    onEditSave={() => void handleSaveRename()}
+                    onEditKeyDown={handleEditKeyDown}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+          <div>
+            <h2 className="text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-3 px-1">
+              All Pages
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {allItems.map((item, index) => (
+                <ExplorerItem
+                  key={`${item.type}-${item.id}`}
+                  item={item}
+                  viewMode="card"
+                  isSelected={selection.isSelected(item.id)}
+                  workspaceSlug={workspaceSlug ?? ''}
+                  onSelect={(e) => {
+                    e.stopPropagation();
+                    selection.toggle({ id: item.id, type: item.type });
+                  }}
+                  onNavigate={(e) => handleItemClick(item, index, e)}
+                  onDelete={() => void handleDeleteItem(item)}
+                  onRename={() => handleRenameItem(item)}
+                  onCopy={() => handleCopyItem(item)}
+                  onCut={() => handleCutItem(item)}
+                  onMove={() => handleMoveItem(item)}
+                  {...(item.type === 'page'
+                    ? {
+                        onExport: () => void handleExport(item.id, item.title),
+                        isFavorite: favoritePageIds.has(item.id),
+                        onToggleFavorite: () => {
+                          void handleToggleFavorite(item.id);
+                        },
+                      }
+                    : {})}
+                  isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
+                  editValue={editingTarget?.value ?? ''}
+                  onEditChange={(value) =>
+                    setEditingTarget((prev) => (prev ? { ...prev, value } : null))
+                  }
+                  onEditSave={() => void handleSaveRename()}
+                  onEditKeyDown={handleEditKeyDown}
+                />
+              ))}
+            </div>
+          </div>
         </div>
       ) : (
-        <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden animate-fade-in">
-          <div className="grid grid-cols-[auto_auto_1fr_auto_auto] gap-3 px-4 py-2 text-xs font-medium text-zinc-400 dark:text-zinc-500 uppercase tracking-wider border-b border-zinc-200 dark:border-zinc-800">
-            <span className="w-5" />
-            <span className="w-8" />
-            <span>Name</span>
-            <span className="hidden md:block w-32 text-right">Last edited</span>
-            <span className="w-8" />
-          </div>
-          <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
-            {allItems.map((item, index) => (
-              <ExplorerItem
-                key={`${item.type}-${item.id}`}
-                item={item}
-                viewMode="list"
-                isSelected={selection.isSelected(item.id)}
-                workspaceSlug={workspaceSlug ?? ''}
-                onSelect={(e) => {
-                  e.stopPropagation();
-                  selection.toggle({ id: item.id, type: item.type });
-                }}
-                onNavigate={(e) => handleItemClick(item, index, e)}
-                onDelete={() => void handleDeleteItem(item)}
-                onRename={() => handleRenameItem(item)}
-                onCopy={() => handleCopyItem(item)}
-                onCut={() => handleCutItem(item)}
-                onMove={() => handleMoveItem(item)}
-                {...(item.type === 'page'
-                  ? { onExport: () => void handleExport(item.id, item.title) }
-                  : {})}
-                isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
-                editValue={editingTarget?.value ?? ''}
-                onEditChange={(value) =>
-                  setEditingTarget((prev) => (prev ? { ...prev, value } : null))
-                }
-                onEditSave={() => void handleSaveRename()}
-                onEditKeyDown={handleEditKeyDown}
-              />
-            ))}
+        <div className="space-y-8">
+          {favoriteItems.length > 0 && (
+            <div>
+              <h2 className="text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-3 px-1">
+                Favorites
+              </h2>
+              <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden">
+                <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                  {favoriteItems.map((item, index) => (
+                    <ExplorerItem
+                      key={`${item.type}-${item.id}`}
+                      item={item}
+                      viewMode="list"
+                      isSelected={selection.isSelected(item.id)}
+                      workspaceSlug={workspaceSlug ?? ''}
+                      onSelect={(e) => {
+                        e.stopPropagation();
+                        selection.toggle({ id: item.id, type: item.type });
+                      }}
+                      onNavigate={(e) => handleItemClick(item, index, e)}
+                      onDelete={() => void handleDeleteItem(item)}
+                      onRename={() => handleRenameItem(item)}
+                      onCopy={() => handleCopyItem(item)}
+                      onCut={() => handleCutItem(item)}
+                      onMove={() => handleMoveItem(item)}
+                      {...(item.type === 'page'
+                        ? {
+                            onExport: () => void handleExport(item.id, item.title),
+                            isFavorite: favoritePageIds.has(item.id),
+                            onToggleFavorite: () => {
+                              void handleToggleFavorite(item.id);
+                            },
+                          }
+                        : {})}
+                      isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
+                      editValue={editingTarget?.value ?? ''}
+                      onEditChange={(value) =>
+                        setEditingTarget((prev) => (prev ? { ...prev, value } : null))
+                      }
+                      onEditSave={() => void handleSaveRename()}
+                      onEditKeyDown={handleEditKeyDown}
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+          <div>
+            <h2 className="text-[11px] font-bold text-zinc-400 dark:text-zinc-500 uppercase tracking-wider mb-3 px-1">
+              All Pages
+            </h2>
+            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden">
+              <div className="grid grid-cols-[auto_auto_1fr_auto_auto] gap-3 px-4 py-2 text-xs font-medium text-zinc-400 dark:text-zinc-500 uppercase tracking-wider border-b border-zinc-200 dark:border-zinc-800">
+                <span className="w-5" />
+                <span className="w-8" />
+                <span>Name</span>
+                <span className="hidden md:block w-32 text-right">Last edited</span>
+                <span className="w-8" />
+              </div>
+              <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                {allItems.map((item, index) => (
+                  <ExplorerItem
+                    key={`${item.type}-${item.id}`}
+                    item={item}
+                    viewMode="list"
+                    isSelected={selection.isSelected(item.id)}
+                    workspaceSlug={workspaceSlug ?? ''}
+                    onSelect={(e) => {
+                      e.stopPropagation();
+                      selection.toggle({ id: item.id, type: item.type });
+                    }}
+                    onNavigate={(e) => handleItemClick(item, index, e)}
+                    onDelete={() => void handleDeleteItem(item)}
+                    onRename={() => handleRenameItem(item)}
+                    onCopy={() => handleCopyItem(item)}
+                    onCut={() => handleCutItem(item)}
+                    onMove={() => handleMoveItem(item)}
+                    {...(item.type === 'page'
+                      ? {
+                          onExport: () => void handleExport(item.id, item.title),
+                          isFavorite: favoritePageIds.has(item.id),
+                          onToggleFavorite: () => {
+                            void handleToggleFavorite(item.id);
+                          },
+                        }
+                      : {})}
+                    isEditing={editingTarget?.kind === item.type && editingTarget.id === item.id}
+                    editValue={editingTarget?.value ?? ''}
+                    onEditChange={(value) =>
+                      setEditingTarget((prev) => (prev ? { ...prev, value } : null))
+                    }
+                    onEditSave={() => void handleSaveRename()}
+                    onEditKeyDown={handleEditKeyDown}
+                  />
+                ))}
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/packages/web/src/routes/Workspace.tsx
+++ b/packages/web/src/routes/Workspace.tsx
@@ -172,6 +172,11 @@ export default function Workspace() {
     [allItems, favoritePageIds],
   );
 
+  const allItemIndexMap = useMemo(
+    () => new Map(allItems.map((item, index) => [item.id, index])),
+    [allItems],
+  );
+
   const handleCreatePage = async () => {
     if (!workspace?.id) return;
     try {
@@ -287,15 +292,11 @@ export default function Workspace() {
   const handleToggleFavorite = async (pageId: string) => {
     if (!workspace?.id) return;
     const isCurrentlyFavorite = favoritePageIds.has(pageId);
-    try {
-      await toggleFavoriteMutation.mutateAsync({
-        pageId,
-        isFavorite: isCurrentlyFavorite,
-        workspaceId: workspace.id,
-      });
-    } catch {
-      showErrorToast(isCurrentlyFavorite ? 'Failed to remove favorite' : 'Failed to add favorite');
-    }
+    await toggleFavoriteMutation.mutateAsync({
+      pageId,
+      isFavorite: isCurrentlyFavorite,
+      workspaceId: workspace.id,
+    });
   };
 
   const handleBulkDelete = async () => {
@@ -563,7 +564,7 @@ export default function Workspace() {
                 Favorites
               </h2>
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                {favoriteItems.map((item, index) => (
+                {favoriteItems.map((item) => (
                   <ExplorerItem
                     key={`${item.type}-${item.id}`}
                     item={item}
@@ -578,7 +579,7 @@ export default function Workspace() {
                       e.stopPropagation();
                       selection.toggle({ id: item.id, type: item.type });
                     }}
-                    onNavigate={(e) => handleItemClick(item, index, e)}
+                    onNavigate={(e) => handleItemClick(item, allItemIndexMap.get(item.id) ?? 0, e)}
                     onDelete={() => void handleDeleteItem(item)}
                     onRename={() => handleRenameItem(item)}
                     onCopy={() => handleCopyItem(item)}
@@ -651,7 +652,7 @@ export default function Workspace() {
               </h2>
               <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl overflow-hidden">
                 <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
-                  {favoriteItems.map((item, index) => (
+                  {favoriteItems.map((item) => (
                     <ExplorerItem
                       key={`${item.type}-${item.id}`}
                       item={item}
@@ -662,7 +663,9 @@ export default function Workspace() {
                         e.stopPropagation();
                         selection.toggle({ id: item.id, type: item.type });
                       }}
-                      onNavigate={(e) => handleItemClick(item, index, e)}
+                      onNavigate={(e) =>
+                        handleItemClick(item, allItemIndexMap.get(item.id) ?? 0, e)
+                      }
                       onDelete={() => void handleDeleteItem(item)}
                       onRename={() => handleRenameItem(item)}
                       onCopy={() => handleCopyItem(item)}


### PR DESCRIPTION
## Summary

- Reordered sidebar: moved action buttons (Home/Import/New Folder/New Page/Expand-Collapse) above the Favorites section
- Added collapsible Favorites and All Pages section headers with chevron icons in the sidebar
- Expand/collapse all now toggles section collapse states alongside folder nodes
- Fixed sidebar favorite toggle to check current state instead of always removing
- Split the home workspace view into Favorites and All Pages sections for both card and list views
- Added Favorite/Unfavorite entry in the three-dot context menu of explorer items

Closes #94