### PR TITLE
fix(deploy): deploy script fixes and migration guide

### DIFF
--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -9,4 +9,5 @@
    - Collab: `node /app/packages/collab/dist/index.js`
 4. **SPA serving**: API container does NOT serve static files. Caddy serves `packages/web/dist` directly.
 5. **PostgreSQL in pod**: port 5432 mapped to `127.0.0.1:5432`. Containers connect via `localhost:5432`.
-6. **db:push after restart**: run `pnpm --filter @markdawn/api db:push` after service restart to sync schema.
+6. **Schema sync**: `setup.sh` runs `db:migrate` followed by a `podman exec` to add any columns that aren't covered by migrations (e.g. `properties` on `pages`). No need to run `db:push` manually.
+7. **Migration cleanup pending**: Issue [#102](https://github.com/atharva-again/Markdawn/issues/102) tracks two schema gaps that need proper migrations after `feat/share-ui` merges. Until then, `setup.sh` has raw SQL workarounds.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -22,8 +22,6 @@ pnpm install
 echo -e "${YELLOW}[STEP 3/6] Building packages...${NC}"
 pnpm --filter @markdawn/shared build
 pnpm --filter @markdawn/web build
-pnpm --filter @markdawn/api build
-pnpm --filter @markdawn/collab build
 
 echo -e "${YELLOW}[STEP 4/6] Updating Podman Quadlet units...${NC}"
 podman volume create postgres-data 2>/dev/null || true
@@ -33,35 +31,38 @@ cp "$REPO_DIR/deploy/quadlet/markdawn-postgres.container" ~/.config/containers/s
 cp "$REPO_DIR/deploy/quadlet/markdawn-api.container" ~/.config/containers/systemd/
 cp "$REPO_DIR/deploy/quadlet/markdawn-collab.container" ~/.config/containers/systemd/
 
-echo -e "${YELLOW}[STEP 5/6] Rebuilding container images...${NC}"
+echo -e "${YELLOW}[STEP 5/7] Rebuilding container images...${NC}"
 podman build -t localhost/markdawn-api:latest -f "$REPO_DIR/deploy/Containerfile.api" "$REPO_DIR"
 podman build -t localhost/markdawn-collab:latest -f "$REPO_DIR/deploy/Containerfile.collab" "$REPO_DIR"
 
-echo -e "${YELLOW}[STEP 6/6] Restarting services...${NC}"
+echo -e "${YELLOW}[STEP 6/7] Running database migrations...${NC}"
+pnpm --filter @markdawn/api db:migrate
+
+echo -e "${YELLOW}[STEP 7/7] Restarting api and collab services...${NC}"
 systemctl --user daemon-reload
 systemctl --user restart \
-  markdawn-pod.service \
-  markdawn-postgres.service \
   markdawn-api.service \
   markdawn-collab.service
 
-echo -e "${YELLOW}[WAIT] Waiting for PostgreSQL to be ready...${NC}"
-for i in {1..30}; do
-    if podman exec markdawn-postgres pg_isready -U markdawn -d markdawn >/dev/null 2>&1; then
-        echo -e "${GREEN}[OK] PostgreSQL is ready.${NC}"
+echo -e "${YELLOW}[CHECK] Verifying API is healthy...${NC}"
+for i in {1..15}; do
+    if curl -sf --max-time 5 "http://127.0.0.1:3001/api/health" > /dev/null 2>&1; then
+        echo -e "${GREEN}[OK] API is healthy.${NC}"
         break
     fi
-    if [ "$i" -eq 30 ]; then
-        echo -e "${RED}[ERROR] PostgreSQL did not become ready in time.${NC}"
+    if [ "$i" -eq 15 ]; then
+        echo -e "${RED}[ERROR] API health check failed after restart.${NC}"
         exit 1
     fi
     sleep 2
 done
 
-echo -e "${YELLOW}[SCHEMA] Pushing database schema...${NC}"
-pnpm --filter @markdawn/api db:migrate
+DEPLOYED_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') deploy: $DEPLOYED_COMMIT" >> "$REPO_DIR/.deploy-log"
 
 echo -e "${GREEN}[DONE] Deployment complete!${NC}"
 echo ""
-echo "Check status: systemctl --user status markdawn-postgres.service markdawn-api.service markdawn-collab.service"
+echo "Deployed commit: $DEPLOYED_COMMIT"
+echo "Check status: systemctl --user status markdawn-api.service markdawn-collab.service"
+echo "View logs:    journalctl --user -u markdawn-api.service -f"
 echo "API health:   curl https://markdawn.space/api/health"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -13,17 +13,17 @@ NC='\033[0m'
 
 cd "$REPO_DIR"
 
-echo -e "${YELLOW}[STEP 1/6] Pulling latest code...${NC}"
+echo -e "${YELLOW}[STEP 1/8] Pulling latest code...${NC}"
 git pull origin master
 
-echo -e "${YELLOW}[STEP 2/6] Installing dependencies...${NC}"
+echo -e "${YELLOW}[STEP 2/8] Installing dependencies...${NC}"
 pnpm install
 
-echo -e "${YELLOW}[STEP 3/6] Building packages...${NC}"
+echo -e "${YELLOW}[STEP 3/8] Building packages...${NC}"
 pnpm --filter @markdawn/shared build
 pnpm --filter @markdawn/web build
 
-echo -e "${YELLOW}[STEP 4/6] Updating Podman Quadlet units...${NC}"
+echo -e "${YELLOW}[STEP 4/8] Updating Podman Quadlet units...${NC}"
 podman volume create postgres-data 2>/dev/null || true
 podman volume create markdawn-data 2>/dev/null || true
 cp "$REPO_DIR/deploy/quadlet/markdawn.pod" ~/.config/containers/systemd/
@@ -31,14 +31,17 @@ cp "$REPO_DIR/deploy/quadlet/markdawn-postgres.container" ~/.config/containers/s
 cp "$REPO_DIR/deploy/quadlet/markdawn-api.container" ~/.config/containers/systemd/
 cp "$REPO_DIR/deploy/quadlet/markdawn-collab.container" ~/.config/containers/systemd/
 
-echo -e "${YELLOW}[STEP 5/7] Rebuilding container images...${NC}"
+echo -e "${YELLOW}[STEP 5/8] Rebuilding container images...${NC}"
 podman build -t localhost/markdawn-api:latest -f "$REPO_DIR/deploy/Containerfile.api" "$REPO_DIR"
 podman build -t localhost/markdawn-collab:latest -f "$REPO_DIR/deploy/Containerfile.collab" "$REPO_DIR"
 
-echo -e "${YELLOW}[STEP 6/7] Running database migrations...${NC}"
+echo -e "${YELLOW}[STEP 6/8] Stopping services before migration...${NC}"
+systemctl --user stop markdawn-api.service markdawn-collab.service
+
+echo -e "${YELLOW}[STEP 7/8] Running database migrations...${NC}"
 pnpm --filter @markdawn/api db:migrate
 
-echo -e "${YELLOW}[STEP 7/7] Restarting api and collab services...${NC}"
+echo -e "${YELLOW}[STEP 8/8] Restarting api and collab services...${NC}"
 systemctl --user daemon-reload
 systemctl --user restart \
   markdawn-api.service \

--- a/deploy/quadlet/markdawn-postgres.container
+++ b/deploy/quadlet/markdawn-postgres.container
@@ -10,7 +10,7 @@ Environment=POSTGRES_USER=markdawn
 Environment=POSTGRES_DB=markdawn
 EnvironmentFile=/var/www/markdawn/.env
 Volume=postgres-data:/var/lib/postgresql/data:Z
-HealthCmd=CMD-SHELL pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+HealthCmd=pg_isready -U markdawn -d markdawn
 HealthInterval=10s
 HealthTimeout=5s
 HealthRetries=5

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -112,7 +112,7 @@ for i in {1..30}; do
 done
 
 echo -e "${YELLOW}[SCHEMA] Running db:migrate to initialize database...${NC}"
-pnpm --filter @markdawn/api db:migrate  
+pnpm --filter @markdawn/api db:migrate
 
 echo -e "${YELLOW}[SCHEMA] Applying schema fixes not covered by migrations...${NC}"
 # TODO(#102): Remove these workarounds after feat/share-ui merges and proper migrations are created

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -15,19 +15,21 @@ if [ "$EUID" -eq 0 ]; then
 fi
 
 echo -e "${YELLOW}[STEP 1/8] Installing common tools, Podman, and Caddy...${NC}"
-sudo dnf install -y git nano curl podman dnf5-plugins
+sudo dnf install -y git nano curl podman dnf5-plugins unzip
 sudo dnf copr enable -y @caddy/caddy
 sudo dnf install -y caddy
+sudo dnf install -y firewalld
+sudo systemctl enable --now firewalld
 sudo firewall-cmd --permanent --add-service=http
 sudo firewall-cmd --permanent --add-service=https
 sudo firewall-cmd --reload
 
 echo -e "${YELLOW}[STEP 2/8] Enabling lingering for user systemd services...${NC}"
-loginctl enable-linger "$(whoami)"
+sudo loginctl enable-linger "$(whoami)"
 
 echo -e "${YELLOW}[STEP 3/8] Preparing repository...${NC}"
 sudo mkdir -p /var/www
-sudo chown "$(whoami):$(whoami)" /var/www
+sudo chown -R "$(whoami):$(whoami)" /var/www
 
 if [ -d ".git" ]; then
     echo -e "${GREEN}[OK] Running from existing repo. Using current directory.${NC}"
@@ -43,7 +45,7 @@ cd "$REPO_DIR"
 echo -e "${YELLOW}[STEP 4/8] Installing Node.js and pnpm...${NC}"
 curl -fsSL https://fnm.vercel.app/install | bash
 export PATH="$HOME/.local/share/fnm:$PATH"
-eval "$(fnm env)"
+eval "$(fnm env --shell bash)"
 fnm install 24
 fnm use 24
 node -v
@@ -63,11 +65,12 @@ echo -e "${YELLOW}[STEP 6/8] Building application...${NC}"
 pnpm install
 pnpm --filter @markdawn/shared build
 pnpm --filter @markdawn/web build
-pnpm --filter @markdawn/api build
-pnpm --filter @markdawn/collab build
 
 echo -e "${YELLOW}[STEP 7/8] Setting up Podman Quadlet services...${NC}"
 mkdir -p ~/.config/containers/systemd
+
+echo -e "${YELLOW}[PULL] Pre-pulling PostgreSQL image to avoid timeout on first start...${NC}"
+podman pull docker.io/library/postgres:17-alpine
 
 podman volume create postgres-data 2>/dev/null || true
 podman volume create markdawn-data 2>/dev/null || true
@@ -108,8 +111,12 @@ for i in {1..30}; do
     sleep 2
 done
 
-echo -e "${YELLOW}[SCHEMA] Running db:push to initialize database...${NC}"
-pnpm --filter @markdawn/api db:push
+echo -e "${YELLOW}[SCHEMA] Running db:migrate to initialize database...${NC}"
+pnpm --filter @markdawn/api db:migrate  
+
+echo -e "${YELLOW}[SCHEMA] Applying schema fixes not covered by migrations...${NC}"
+# TODO(#102): Remove these workarounds after feat/share-ui merges and proper migrations are created
+podman exec markdawn-postgres psql -U markdawn -d markdawn -c "ALTER TABLE pages ADD COLUMN IF NOT EXISTS properties jsonb;"
 
 systemctl --user start markdawn-api.service markdawn-collab.service
 

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -117,7 +117,7 @@ This script will:
 4. Copy Quadlet files to `~/.config/containers/systemd/`
 5. Build container images
 6. Start PostgreSQL and wait for it to be healthy
-7. Run `db:push` to initialize the database schema
+7. Run `db:migrate` to initialize the database schema (followed by `podman exec` to add any columns not covered by existing migrations)
 8. Start API and Collab systemd user services
 
 ### 8. Verify Deployment

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -1,0 +1,130 @@
+# Markdawn Server Migration Guide
+
+A runbook for moving a Markdawn production deployment from one Linux VM to another.
+
+**Assumptions:** Old and new servers are both Fedora 43, Podman rootless, DNS hosted externally, you have sudo on both.
+
+> **Tracking issue:** [#102](https://github.com/atharva-again/Markdawn/issues/102) — two schema gaps that still need proper migrations.
+
+---
+
+## What moves and what doesn't
+
+| Moves | Stays behind |
+|-------|-------------|
+| PostgreSQL database (pg_dump / restore) | Container images (rebuilt by `setup.sh`) |
+| Uploaded files in `markdawn-data` volume | Quadlet files (copied from repo) |
+| `.env` file (secrets, OAuth keys) | Caddy binary + config (installed by `setup.sh`) |
+| | Let's Encrypt cert (auto-provisioned after DNS flip) |
+
+---
+
+## Phase 1: Set up the new server
+
+```bash
+sudo dnf install -y git
+git clone https://github.com/atharva-again/markdawn.git /var/www/markdawn
+cd /var/www/markdawn
+./deploy/setup.sh
+```
+
+This installs everything, builds containers, starts Postgres, runs `db:migrate`, and starts the API and Collab.
+
+### Verify the new server works
+
+```bash
+curl http://localhost:3001/api/health
+# → {"status":"ok","timestamp":...}
+```
+
+---
+
+## Phase 2: Move the data
+
+Do this while the old server is still running.
+
+**Dump the database on the old server:**
+```bash
+podman exec markdawn-postgres pg_dump -U markdawn -d markdawn --no-owner > /tmp/markdawn-db-dump.sql
+```
+
+**Copy uploaded files:**
+```bash
+podman volume export markdawn-data > /tmp/markdawn-data.tar
+```
+
+**Copy both to your laptop, then to the new server:**
+```bash
+scp old-server:/tmp/markdawn-db-dump.sql /tmp/
+scp old-server:/tmp/markdawn-data.tar /tmp/
+scp /tmp/markdawn-db-dump.sql new-server:/tmp/
+scp /tmp/markdawn-data.tar new-server:/tmp/
+scp /tmp/.env new-server:/var/www/markdawn/.env
+```
+
+**On the new server, stop the app containers and restore:**
+```bash
+systemctl --user stop markdawn-api.service markdawn-collab.service
+cat /tmp/markdawn-db-dump.sql | podman exec -i markdawn-postgres psql -U markdawn -d markdawn
+podman volume import markdawn-data /tmp/markdawn-data.tar
+```
+
+**Run migrations and start services:**
+```bash
+cd /var/www/markdawn
+pnpm --filter @markdawn/api db:migrate
+# Apply schema fixes not covered by migrations (see #102)
+podman exec markdawn-postgres psql -U markdawn -d markdawn \
+  -c "ALTER TABLE pages ADD COLUMN IF NOT EXISTS properties jsonb;"
+systemctl --user start markdawn-api.service markdawn-collab.service
+```
+
+---
+
+## Phase 3: Cut over
+
+1. **Update DNS** — point the A record to the new server's IP
+2. **Restart Caddy** to force cert provisioning:
+   ```bash
+   sudo systemctl restart caddy
+   ```
+3. **Verify:**
+   ```bash
+   curl https://markdawn.space/api/health
+   # Try opening a page and typing in the browser
+   ```
+4. **(Optional) Shut down the old server**
+
+---
+
+## Gotchas
+
+### Quadlet `HealthCmd` doesn't expand variables
+`HealthCmd=CMD-SHELL pg_isready -U "$POSTGRES_USER"` breaks with `unterminated quoted string`. Hardcode the values:
+```
+HealthCmd=pg_isready -U markdawn -d markdawn
+```
+
+### `db:push` silently covers migration gaps
+It syncs schema directly AND updates Drizzle's internal snapshot. Subsequent `drizzle-kit generate` sees no diff and skips creating migrations. Always use `db:migrate` in production.
+
+### Podman rootless needs `:Z` on volume mounts
+Without it, container processes can't read mounted files (like `.env`). The Postgres quadlet uses `Volume=postgres-data:/var/lib/postgresql/data:Z` — keep the `:Z`.
+
+### Caddy needs a restart after DNS change
+```bash
+sudo systemctl restart caddy
+```
+Without this, you wait up to an hour for the next cert check cycle.
+
+## Quick Reference
+
+| What | Command |
+|------|---------|
+| Check services | `systemctl --user status markdawn-api.service markdawn-collab.service` |
+| View API logs | `journalctl --user -u markdawn-api.service -f` |
+| View Collab logs | `journalctl --user -u markdawn-collab.service -f` |
+| Restart | `systemctl --user restart markdawn-api.service markdawn-collab.service` |
+| API health | `curl https://markdawn.space/api/health` |
+| Dump DB | `podman exec markdawn-postgres pg_dump -U markdawn -d markdawn --no-owner > dump.sql` |
+| Restore DB | `cat dump.sql \| podman exec -i markdawn-postgres psql -U markdawn -d markdawn` |

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -53,10 +53,11 @@ podman exec markdawn-postgres pg_dump -U markdawn -d markdawn --no-owner > /tmp/
 podman volume export markdawn-data > /tmp/markdawn-data.tar
 ```
 
-**Copy both to your laptop, then to the new server:**
+**Copy everything to your laptop, then to the new server:**
 ```bash
 scp old-server:/tmp/markdawn-db-dump.sql /tmp/
 scp old-server:/tmp/markdawn-data.tar /tmp/
+scp old-server:/var/www/markdawn/.env /tmp/
 scp /tmp/markdawn-db-dump.sql new-server:/tmp/
 scp /tmp/markdawn-data.tar new-server:/tmp/
 scp /tmp/.env new-server:/var/www/markdawn/.env
@@ -127,4 +128,4 @@ Without this, you wait up to an hour for the next cert check cycle.
 | Restart | `systemctl --user restart markdawn-api.service markdawn-collab.service` |
 | API health | `curl https://markdawn.space/api/health` |
 | Dump DB | `podman exec markdawn-postgres pg_dump -U markdawn -d markdawn --no-owner > dump.sql` |
-| Restore DB | `cat dump.sql \| podman exec -i markdawn-postgres psql -U markdawn -d markdawn` |
+| Restore DB | `cat dump.sql | podman exec -i markdawn-postgres psql -U markdawn -d markdawn` |


### PR DESCRIPTION
## Summary

Fixes to deploy scripts discovered during the Vultr-to-DO VM migration. Makes `db:migrate` work out of the box on fresh Fedora 43 VMs.

## Changes

### Fixes
- **Quadlet health check**: Hardcoded Postgres health check values (`$POSTGRES_USER` breaks in Quadlet's CMD-SHELL)
- **setup.sh**: Enable firewalld immediately, fix `fnm env` for bash, add `ALTER TABLE` for missing `properties` column
- **deploy.sh**: Migrate before restart, API health check instead of Postgres wait, deploy log tracking

### Docs
- **AGENTS.md**: Updated gotchas for `db:migrate` workflow
- **deployment_guide.md**: Updated step 7 to reflect current workflow
- **migration_guide.md**: New runbook for server-to-server migration with all gotchas documented

## Tracking
Referenced in issue #102 — pending migration cleanup after `feat/share-ui` merges.